### PR TITLE
boilerplate header improvements

### DIFF
--- a/hack/boilerplate/boilerplate.Dockerfile.txt
+++ b/hack/boilerplate/boilerplate.Dockerfile.txt
@@ -1,4 +1,4 @@
-# Copyright YEAR The Kubecarrier authors.
+# Copyright YEAR The Kubecarrier Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate.py.txt
+++ b/hack/boilerplate/boilerplate.py.txt
@@ -1,4 +1,4 @@
-# Copyright YEAR The XXX Authors.
+# Copyright YEAR The Kubecarrier Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Make the `authors` to `Authors` in the dockerfile boilerplate code, to make it unify with other boilerplate templates.
- Replace 'XXX' with Kubecarrier in the boilerplate.py.txt