### PR TITLE
added push-image-test CI hook in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,7 @@ build-image-test:
 	@docker build -t ${IMAGE_ORG}/test bin/image/test
 
 push-image-test: build-image-test
+	@[[ -z $${CI:-} ]] || ( start-docker.sh && docker login -u ${QUAY_IO_USERNAME} -p ${QUAY_IO_PASSWORD} quay.io )
 	@docker push ${IMAGE_ORG}/test
 	@echo pushed ${IMAGE_ORG}/test
 


### PR DESCRIPTION
**What this PR does / why we need it**:

It adds `start-docker.sh` and `docker login` to `push-image-test` Makefile target. Combined with infra PR counterpart ( https://github.com/kubermatic/infra/pull/768 )  this rebuilds test image on the newest master branch and pushes it to the `quay.io` repo

```release-note
NONE
```
