### PR TITLE
Remove the flaky test of KubeCarrier Terminating Checking

### DIFF
--- a/test/installation/installation.go
+++ b/test/installation/installation.go
@@ -154,16 +154,6 @@ func (s *InstallationSuite) TestInstallAndTeardown() {
 				}
 				return false, err
 			}
-
-			// Since the Deployment is not deleted, here check if the KubeCarrier status is Terminating.
-			if s.NoError(s.masterClient.Get(ctx, types.NamespacedName{
-				Name:      "kubecarrier",
-				Namespace: nn,
-			}, kubeCarrier), "getting the KubeCarrier error") {
-				readyCondition, readyConditionExists := kubeCarrier.Status.GetCondition(operatorv1alpha1.KubeCarrierReady)
-				s.True(readyConditionExists, "Ready Condition is not set")
-				s.Equal(operatorv1alpha1.ConditionTrue, readyCondition.Status, "Wrong Ready condition.Status")
-			}
 			return false, nil
 		}), "get the Deployment that owned by KubeCarrier object")
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the e2e test which checks the KubeCarrier Terminating Phase Checking. This test is flaky, since these 2 cases may happen:
- KubeCarrier object is removed really quick, so there receives NotFound error. 
- KubeCarrier is still ready since there are still requests in the queue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
