### PR TITLE
Added gen-intelij taks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,3 +145,6 @@ require-docker:
 	@docker ps > /dev/null 2>&1 || start-docker.sh || (echo "cannot find running docker daemon nor can start new one" && false)
 	@[[ -z "${QUAY_IO_USERNAME}" ]] || ( echo "logging in to ${QUAY_IO_USERNAME}" && docker login -u ${QUAY_IO_USERNAME} -p ${QUAY_IO_PASSWORD} quay.io )
 .PHONEY: require-docker
+
+generate-intelij-tasks:
+	@./hack/gen-intelij-tasks.sh ${LD_FLAGS}

--- a/hack/gen-intelij-tasks.sh
+++ b/hack/gen-intelij-tasks.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The KubeCarrier Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+LD_FLAGS=${1//-w/}
+GIT_ROOT=$(git rev-parse --show-toplevel)
+
+
+cat << EOF > ${GIT_ROOT}/.idea/runConfigurations/kubecarrier_operator.xml
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="kubecarrier:operator" type="GoApplicationRunConfiguration" factoryName="Go Application">
+    <module name="kubecarrier" />
+    <working_directory value="\$PROJECT_DIR\$/" />
+    <go_parameters value="-i -ldflags &quot;${LD_FLAGS}&quot;" />
+    <kind value="DIRECTORY" />
+    <filePath value="\$PROJECT_DIR\$/|\$PROJECT_DIR\$/cmd/operator/main.go" />
+    <package value="github.com/kubermatic/kubecarrier" />
+    <directory value="\$PROJECT_DIR\$/cmd/operator" />
+    <method v="2" />
+  </configuration>
+</component>
+EOF
+
+cat << EOF > ${GIT_ROOT}/.idea/runConfigurations/kubecarrier_tender.xml
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="kubecarrier:tender" type="GoApplicationRunConfiguration" factoryName="Go Application">
+    <module name="kubecarrier" />
+    <working_directory value="\$PROJECT_DIR\$/" />
+    <go_parameters value="-i -ldflags &quot;${LD_FLAGS}&quot;" />
+    <parameters value="--provider-namespace=default --service-cluster-name=default --service-cluster-kubeconfig=\$USER_HOME\$/.kube/internal-kind-config-kubecarrier-svc-1" />
+    <kind value="DIRECTORY" />
+    <filePath value="\$PROJECT_DIR\$/|\$PROJECT_DIR\$/cmd/tender/main.go" />
+    <package value="github.com/kubermatic/kubecarrier" />
+    <directory value="\$PROJECT_DIR\$/cmd/tender" />
+    <method v="2" />
+  </configuration>
+</component>
+EOF


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds inteliJ tasks generator for inteliJ suite of IDE tools (Goland for example). This is needed to ease the debugging and development due to requirements for `${LD_FLAGS}` to run almost all operators properly (especially the kubecarrier operator). This simplifies this procedure by running `make generate-intelij-tasks` after last commit to have up-to-date. 

I'd also recommend putting this makefile target into both [post-commit](https://www.git-scm.com/docs/githooks#_post_commit) and [post-checkout](https://www.git-scm.com/docs/githooks#_post_checkout) git hooks to always be up to date. 

```release-note
NONE
```
