### PR TITLE
Added boilerplate fileContent check

### DIFF
--- a/hack/boilerplate/boilerplate.go
+++ b/hack/boilerplate/boilerplate.go
@@ -218,8 +218,10 @@ func filePasses(filename string, boilerplateMap map[string]string, out io.Writer
 		fileContent = shebangRe.ReplaceAll(fileContent, nil)
 	}
 
-	// trim the file to the same length as our boilerplate header
-	fileContent = fileContent[0:len(boilerplate)]
+	if len(boilerplate) <= len(fileContent) {
+		// trim the file to the same length as our boilerplate header
+		fileContent = fileContent[0:len(boilerplate)]
+	}
 
 	// is YEAR in the file
 	if yearRe.Match(fileContent) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR checks the file length before truncating the file. In the past, if the file was shorter then the boilerplate length, the `boilerplate.go` would panic without emitting the offening file's name. This PR fixes this as well as providing better error messages when it happens (via the appropriate diffing between file's content and the boilerplate header) 


```release-note
NONE
```
