### PR TITLE
Added logging mixin for commands

### DIFF
--- a/cmd/anchor/main.go
+++ b/cmd/anchor/main.go
@@ -20,33 +20,14 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/go-logr/logr"
-	"go.uber.org/zap"
 	ctrl "sigs.k8s.io/controller-runtime"
-	corezap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/kubermatic/kubecarrier/pkg/anchor"
 )
 
 func main() {
-	level := zap.NewAtomicLevel()
-	ctrl.SetLogger(corezap.New(func(options *corezap.Options) {
-		options.Level = &level
-		options.Development = true
-	}))
-
-	log := ctrl.Log.WithName("anchor")
-	if err := anchor.NewAnchor(&logWrapper{Logger: log, level: &level}).Execute(); err != nil {
+	if err := anchor.NewAnchor(ctrl.Log.WithName("anchor")).Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-}
-
-type logWrapper struct {
-	logr.Logger
-	level *zap.AtomicLevel
-}
-
-func (w *logWrapper) GetLevel() *zap.AtomicLevel {
-	return w.level
 }

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -20,18 +20,12 @@ import (
 	"os"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/kubermatic/kubecarrier/pkg/manager"
 )
 
 func main() {
-	ctrl.SetLogger(zap.New(func(options *zap.Options) {
-		options.Development = true
-	}))
-
-	log := ctrl.Log.WithName("manager")
-	command := manager.NewManagerCommand(log)
+	command := manager.NewManagerCommand(ctrl.Log.WithName("manager"))
 
 	if err := command.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -20,20 +20,14 @@ import (
 	"os"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/kubermatic/kubecarrier/pkg/operator"
 )
 
 func main() {
-	ctrl.SetLogger(zap.New(func(options *zap.Options) {
-		options.Development = true
-	}))
+	cmd := operator.NewOperatorCommand(ctrl.Log.WithName("operator"))
 
-	log := ctrl.Log.WithName("operator")
-	command := operator.NewOperatorCommand(log)
-
-	if err := command.Execute(); err != nil {
+	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.4.0
 	go.uber.org/zap v1.10.0
+	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413
 	k8s.io/api v0.0.0-20190918195907-bd6ac527cfd2
 	k8s.io/apiextensions-apiserver v0.0.0-20190918201827-3de75813f604
 	k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d

--- a/go.sum
+++ b/go.sum
@@ -405,6 +405,8 @@ golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8 h1:1wopBVtVdWnn03fZelqdXT
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7 h1:0hQKqeLdqlt5iIwVOBErRisrHJAN57yOiPRQItI20fU=
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 h1:ULYEB3JvPRE/IfO+9uO7vKV/xzVTO7XPAwm8xbf4w2g=
+golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190312203227-4b39c73a6495/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=

--- a/pkg/anchor/internal/cmd/root.go
+++ b/pkg/anchor/internal/cmd/root.go
@@ -19,42 +19,23 @@ package cmd
 import (
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/kubermatic/kubecarrier/pkg/anchor/internal/cmd/completion"
 	e2e_test "github.com/kubermatic/kubecarrier/pkg/anchor/internal/cmd/e2e-test"
 	"github.com/kubermatic/kubecarrier/pkg/anchor/internal/cmd/setup"
 	"github.com/kubermatic/kubecarrier/pkg/anchor/internal/cmd/version"
+	"github.com/kubermatic/kubecarrier/pkg/internal/util"
 )
-
-type levelAccessor interface {
-	GetLevel() *zap.AtomicLevel
-}
-
-type flagpole struct {
-	Verbosity int8
-}
 
 // NewAnchor creates the root command for the anchor CLI.
 func NewAnchor(log logr.Logger) *cobra.Command {
-	flags := &flagpole{}
 	cmd := &cobra.Command{
 		Use:   "anchor",
 		Short: "Anchor is the CLI tool for managing KubeCarrier",
 		Long: `Anchor is a CLI library for managing KubeCarrier,
 Documentation is available in the project's repository:
 https://github.com/kubermatic/kubecarrier`,
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			la, ok := log.(levelAccessor)
-			if !ok {
-				return
-			}
-			la.GetLevel().SetLevel(zapcore.Level(-1 * flags.Verbosity))
-		},
 	}
-
-	cmd.PersistentFlags().Int8VarP(&flags.Verbosity, "verbosity", "v", 0, "logging verbosity")
 
 	cmd.AddCommand(
 		completion.NewCommand(log),
@@ -63,5 +44,5 @@ https://github.com/kubermatic/kubecarrier`,
 		version.NewCommand(log),
 	)
 
-	return cmd
+	return util.CmdLogMixin(cmd)
 }

--- a/pkg/internal/util/cmd.go
+++ b/pkg/internal/util/cmd.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2019 The KubeCarrier Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"golang.org/x/crypto/ssh/terminal"
+	ctrl "sigs.k8s.io/controller-runtime"
+	corezap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// CmdLogMixin adds necessary CLI flags for logging and setups the controller runtime log
+func CmdLogMixin(cmd *cobra.Command) *cobra.Command {
+	dev := cmd.PersistentFlags().Bool("development", terminal.IsTerminal(int(os.Stdout.Fd())), "format output for console")
+	v := cmd.PersistentFlags().Int8P("verbose", "v", 0, "verbosity level")
+
+	if cmd.PersistentPreRunE != nil {
+		parent := cmd.PersistentPreRunE
+		cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+			ctrl.SetLogger(corezap.New(func(options *corezap.Options) {
+				level := zap.NewAtomicLevelAt(zapcore.Level(-*v))
+				options.Level = &level
+				options.Development = *dev
+			}))
+			return parent(c, args)
+		}
+		return cmd
+	}
+
+	parent := cmd.PersistentPreRun
+	cmd.PersistentPreRun = func(c *cobra.Command, args []string) {
+		ctrl.SetLogger(corezap.New(func(options *corezap.Options) {
+			level := zap.NewAtomicLevelAt(zapcore.Level(-*v))
+			options.Level = &level
+			options.Development = *dev
+		}))
+		if parent != nil {
+			parent(c, args)
+		}
+	}
+	return cmd
+}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -28,6 +28,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	catalogv1alpha1 "github.com/kubermatic/kubecarrier/pkg/apis/catalog/v1alpha1"
+	"github.com/kubermatic/kubecarrier/pkg/internal/util"
 	"github.com/kubermatic/kubecarrier/pkg/manager/internal/controllers"
 )
 
@@ -64,7 +65,7 @@ func NewManagerCommand(log logr.Logger) *cobra.Command {
 	cmd.Flags().BoolVar(&flags.enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	cmd.Flags().StringVar(&flags.kubeCarrierSystemNamespace, "kubecarrier-system-namespace", os.Getenv("KUBECARRIER_NAMESPACE"), "The namespace that KubeCarrier controller manager deploys to.")
-	return cmd
+	return util.CmdLogMixin(cmd)
 }
 
 func run(flags *flags, log logr.Logger) error {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -67,7 +67,7 @@ func NewOperatorCommand(log logr.Logger) *cobra.Command {
 	cmd.Flags().StringVar(&flags.metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	cmd.Flags().BoolVar(&flags.enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for operator. Enabling this will ensure there is only one active controller manager.")
-	return cmd
+	return util.CmdLogMixin(cmd)
 }
 
 func run(flags *flags, log logr.Logger) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces small logging mixin which takes existing `*cobra.Command` and inserts additional `PersistentPreRunE`/`PersistentPreRun` setting up the `controller-runtime` logging. Furthermore, it adds necessary `PersistentFlags` to that cobra command, making this utility function a one-stop-shop for logging needs.

Test-plan:
* I've tested logging via supplied logger for level 0-9 and default one. (e.g. `log.V(level).Info("test")`) The `controller-runtime`s logger is delegating one, thus its reference does not change between the `SetLogger` calls (it's indirect logger that is, proxying the log to the read underlying log object which is changed via the `SetLogger` function)  

```release-note
NONE
```
