### PR TITLE
Using `ed` instead of `sed` to generate the RBAC of ferry and catapult.

### DIFF
--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -80,7 +80,11 @@ statik-gen manager config/internal/manager
 # -------
 # RBAC
 $CONTROLLER_GEN rbac:roleName=manager-role paths="./pkg/ferry/..." output:rbac:artifacts:config=config/internal/ferry/rbac
-sed -i 's/ClusterRole/Role/g' config/internal/ferry/rbac/role.yaml
+# The `|| true` is because the `,s/ClusterRole/Role/g` will error out if there is no match of `ClusterRole` (eg., the file is empty) in the file.
+ed config/internal/manager/rbac/role.yaml <<EOF || true
+,s/ClusterRole/Role/g
+w
+EOF
 # Statik (run only when file CONTENT has changed)
 statik-gen ferry config/internal/ferry
 
@@ -88,5 +92,9 @@ statik-gen ferry config/internal/ferry
 # -------
 # RBAC
 $CONTROLLER_GEN rbac:roleName=manager-role paths="./pkg/catapult/..." output:rbac:artifacts:config=config/internal/catapult/rbac
-sed -i 's/ClusterRole/Role/g' config/internal/catapult/rbac/role.yaml
+# The `|| true` is because the `,s/ClusterRole/Role/g` will error out if there is no match of `ClusterRole` (eg., the file is empty) in the file.
+ed config/internal/catapult/rbac/role.yaml <<EOF || true
+,s/ClusterRole/Role/g
+w
+EOF
 statik-gen catapult config/internal/catapult


### PR DESCRIPTION
**What this PR does / why we need it**:
The root issue of this PR is that  `sed -i` works differently between Linux and Mac OSX: #84, and the sed is Stream EDitor, and the `-i` flag is used to handle non-streams, so we can just use `ed` to handle that

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
