### PR TITLE
manager enable leader election

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -71,7 +71,7 @@ func NewManagerCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flags.metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
-	cmd.Flags().BoolVar(&flags.enableLeaderElection, "enable-leader-election", false,
+	cmd.Flags().BoolVar(&flags.enableLeaderElection, "enable-leader-election", true,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	cmd.Flags().StringVar(&flags.kubeCarrierSystemNamespace, "kubecarrier-system-namespace", os.Getenv("KUBECARRIER_NAMESPACE"), "The namespace that KubeCarrier controller manager deploys to.")
 	return util.CmdLogMixin(cmd)
@@ -79,10 +79,12 @@ func NewManagerCommand() *cobra.Command {
 
 func run(flags *flags, log logr.Logger) error {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:             scheme,
-		MetricsBindAddress: flags.metricsAddr,
-		LeaderElection:     flags.enableLeaderElection,
-		Port:               9443,
+		Scheme:                  scheme,
+		MetricsBindAddress:      flags.metricsAddr,
+		LeaderElection:          flags.enableLeaderElection,
+		LeaderElectionID:        "main-controller-manager",
+		LeaderElectionNamespace: flags.kubeCarrierSystemNamespace,
+		Port:                    9443,
 	})
 	if err != nil {
 		return fmt.Errorf("starting manager: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
The two manager pods could coexist at the same time leading to race conditions. This enables the leader election on them. There are some other fixes included in the PR to make e2e tests pass:

```release-note
NONE
```