### PR TITLE
Remove duplicated definitions of object interface and use util.Object

### DIFF
--- a/pkg/internal/util/namespace.go
+++ b/pkg/internal/util/namespace.go
@@ -28,15 +28,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
-type object interface {
-	metav1.Object
-	runtime.Object
-}
-
 // EnsureUniqueNamespace generates unique namespace for obj if one already doesn't exists
 //
 // It's required that OwnerReverseFieldIndex exists for corev1.Namespace
-func EnsureUniqueNamespace(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner object) (*corev1.Namespace, error) {
+func EnsureUniqueNamespace(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner Object) (*corev1.Namespace, error) {
 	namespaceList := &corev1.NamespaceList{}
 	if err := c.List(ctx, namespaceList, OwnedBy(owner, scheme)); err != nil {
 		return nil, fmt.Errorf("listing Namespaces: %w", err)

--- a/pkg/manager/internal/controllers/catalog_controller.go
+++ b/pkg/manager/internal/controllers/catalog_controller.go
@@ -551,29 +551,24 @@ func (r *CatalogReconciler) cleanupServiceClusterReferences(
 		serviceClusterReferencesToObjectArray(desiredServiceClusterReferences))
 }
 
-type object interface {
-	metav1.Object
-	runtime.Object
-}
-
-func offeringsToObjectArray(offerings []catalogv1alpha1.Offering) []object {
-	out := make([]object, len(offerings))
+func offeringsToObjectArray(offerings []catalogv1alpha1.Offering) []util.Object {
+	out := make([]util.Object, len(offerings))
 	for i := range offerings {
 		out[i] = &offerings[i]
 	}
 	return out
 }
 
-func providerReferencesToObjectArray(providerReferences []catalogv1alpha1.ProviderReference) []object {
-	out := make([]object, len(providerReferences))
+func providerReferencesToObjectArray(providerReferences []catalogv1alpha1.ProviderReference) []util.Object {
+	out := make([]util.Object, len(providerReferences))
 	for i := range providerReferences {
 		out[i] = &providerReferences[i]
 	}
 	return out
 }
 
-func serviceClusterReferencesToObjectArray(serviceClusterReferences []catalogv1alpha1.ServiceClusterReference) []object {
-	out := make([]object, len(serviceClusterReferences))
+func serviceClusterReferencesToObjectArray(serviceClusterReferences []catalogv1alpha1.ServiceClusterReference) []util.Object {
+	out := make([]util.Object, len(serviceClusterReferences))
 	for i := range serviceClusterReferences {
 		out[i] = &serviceClusterReferences[i]
 	}
@@ -583,8 +578,8 @@ func serviceClusterReferencesToObjectArray(serviceClusterReferences []catalogv1a
 func (r *CatalogReconciler) cleanupOutdatedReferences(
 	ctx context.Context, log logr.Logger,
 	catalog *catalogv1alpha1.Catalog,
-	foundObjects []object,
-	desiredObjects []object,
+	foundObjects []util.Object,
+	desiredObjects []util.Object,
 ) (deletedObjectCounter int, err error) {
 	desiredObjectMap := map[string]struct{}{}
 	for _, desiredObject := range desiredObjects {


### PR DESCRIPTION
**What this PR does / why we need it**:
There are a few duplicated definitions of the object interfaces in the `pkg/internal/util/namespaces.go` and `pkg/manager/internal/controllers/catalog_controller.go`, this PR just removes them and use the `Object` that defines in the `util` pkg.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
