### PR TITLE
Update the cert-manager from v0.11.0 to v0.13.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,4 +168,4 @@ install-git-hooks:
 # Install cert-manager in the configured Kubernetes cluster
 cert-manager:
 	kubectl create namespace cert-manager || true
-	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.11.0/cert-manager.yaml
+	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.13.0/cert-manager.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
Since they refactored the `webhook` component in v0.12.0, and it is faster to be deployed, this updating can make our e2e tests less flaky(one cause is that cert-manger takes a long time to deploy). 

There is no broken API changes between v0.11.0 and v0.13.0
They mentioned in their [Release Notes of v0.12.0](https://cert-manager.io/docs/release-notes/release-notes-0.12/#simplifying-the-webhook-component) that they have refactored the `webhook` component, and it will be faster to deploy `webhook` component.
Between v0.12.0 and v0.13.0, there are some bug fixes, and some notable changes, but no broken API.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
