### PR TITLE
Fix test docker image building

### DIFF
--- a/config/dockerfiles/test.Dockerfile
+++ b/config/dockerfiles/test.Dockerfile
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Should be build from the Makefile, `make build-image-test`
+
 FROM ubuntu:18.04
 
 RUN apt-get -qq update && apt-get -qqy install \


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes broken docker test image building

https://prow.loodse.com/view/gcs/prow-data/logs/post-kubecarrier-test-image/1224731241849294848

```release-note
NONE
```
