### PR TITLE
[WIP] Added -trimpath to our build flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ bin/windows_amd64/%: GOARGS = GOOS=windows GOARCH=amd64
 
 bin/%: FORCE
 	$(eval COMPONENT=$(shell basename $*))
-	$(GOARGS) go build -ldflags "-w $(LD_FLAGS)" -o bin/$* cmd/$(COMPONENT)/main.go
+	$(GOARGS) go build -trimpath -ldflags "-w $(LD_FLAGS)" -o bin/$* cmd/$(COMPONENT)/main.go
 
 FORCE:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `-trimpath` flag to the go's build. This is 1.13 flag which normalizes the file paths within the resulting binary regardless of the build directory. Thus panic's etc would print the same stack trace whether the binary is built via the CI, or someone builds it locally. 

```
-trimpath prefix
	Remove prefix from recorded source file paths.
```

```release-note
NONE
```
