### PR TITLE
Removed unneeded prints

### DIFF
--- a/pkg/internal/resources/catapult/catapult.go
+++ b/pkg/internal/resources/catapult/catapult.go
@@ -142,7 +142,6 @@ func Manifests(c Config) ([]unstructured.Unstructured, error) {
 		},
 	}
 	managerEnvBytes, err := yaml.Marshal(managerEnv)
-	fmt.Println(string(managerEnvBytes))
 	if err != nil {
 		return nil, fmt.Errorf("marshalling manager env patch: %w", err)
 	}

--- a/pkg/internal/resources/elevator/elevator.go
+++ b/pkg/internal/resources/elevator/elevator.go
@@ -121,7 +121,6 @@ func Manifests(c Config) ([]unstructured.Unstructured, error) {
 		},
 	}
 	managerEnvBytes, err := yaml.Marshal(managerEnv)
-	fmt.Println(string(managerEnvBytes))
 	if err != nil {
 		return nil, fmt.Errorf("marshalling manager env patch: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Upon inspecting kubecarrier e2e logs I found unneeded stdout prints. This PR removes it. 

```release-note
NONE
```
