### PR TITLE
Rename crdiscovery variables to crDiscovery

### DIFF
--- a/pkg/ferry/internal/controllers/customresourcediscovery_controller.go
+++ b/pkg/ferry/internal/controllers/customresourcediscovery_controller.go
@@ -60,7 +60,7 @@ type CustomResourceDiscoveryReconciler struct {
 
 func (r *CustomResourceDiscoveryReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
-	log := r.Log.WithValues("crdiscoveryy", req.NamespacedName)
+	log := r.Log.WithValues("crdiscovery", req.NamespacedName)
 
 	crDiscovery := &corev1alpha1.CustomResourceDiscovery{}
 	if err := r.MasterClient.Get(ctx, req.NamespacedName, crDiscovery); err != nil {

--- a/pkg/manager/internal/controllers/customresourcediscoveryset_controller.go
+++ b/pkg/manager/internal/controllers/customresourcediscoveryset_controller.go
@@ -37,7 +37,7 @@ import (
 	"github.com/kubermatic/kubecarrier/pkg/internal/util"
 )
 
-const crdiscoveriesLabel = "crdiscoveries.kubecarrier.io/controlled-by"
+const crDiscoveriesLabel = "crdiscoveries.kubecarrier.io/controlled-by"
 
 // CustomResourceDiscoverySetReconciler reconciles a CustomResourceDiscovery object
 type CustomResourceDiscoverySetReconciler struct {
@@ -103,21 +103,21 @@ func (r *CustomResourceDiscoverySetReconciler) Reconcile(req ctrl.Request) (ctrl
 	}
 
 	// Cleanup uncontrolled CRDiscoveries
-	crdiscoveryList := &corev1alpha1.CustomResourceDiscoveryList{}
-	if err := r.List(ctx, crdiscoveryList, client.MatchingLabels{
-		crdiscoveriesLabel: crDiscoverySet.Name,
+	crDiscoveryList := &corev1alpha1.CustomResourceDiscoveryList{}
+	if err := r.List(ctx, crDiscoveryList, client.MatchingLabels{
+		crDiscoveriesLabel: crDiscoverySet.Name,
 	}); err != nil {
 		return result, fmt.Errorf(
 			"listing all CustomResourceDiscovery for this Set: %w", err)
 	}
-	for _, crdiscovery := range crdiscoveryList.Items {
-		_, ok := existingCRDiscoveryNames[crdiscovery.Name]
+	for _, crDiscovery := range crDiscoveryList.Items {
+		_, ok := existingCRDiscoveryNames[crDiscovery.Name]
 		if ok {
 			continue
 		}
 
-		// delete crdiscovery that should no longer exist
-		if err := r.Delete(ctx, &crdiscovery); err != nil {
+		// delete crDiscovery that should no longer exist
+		if err := r.Delete(ctx, &crDiscovery); err != nil {
 			return result, fmt.Errorf("deleting CustomResourceDiscovery: %w", err)
 		}
 	}
@@ -158,7 +158,7 @@ func (r *CustomResourceDiscoverySetReconciler) reconcileCRDiscovery(
 			Name:      crDiscoverySet.Name + "." + serviceCluster.Name,
 			Namespace: crDiscoverySet.Namespace,
 			Labels: map[string]string{
-				crdiscoveriesLabel: crDiscoverySet.Name,
+				crDiscoveriesLabel: crDiscoverySet.Name,
 			},
 		},
 		Spec: corev1alpha1.CustomResourceDiscoverySpec{
@@ -206,7 +206,7 @@ func (r *CustomResourceDiscoverySetReconciler) SetupWithManager(mgr ctrl.Manager
 			crdsList := &corev1alpha1.CustomResourceDiscoverySetList{}
 			if err := r.List(context.Background(), crdsList, client.InNamespace(mapObject.Meta.GetNamespace())); err != nil {
 				// This will makes the manager crashes, and it will restart and reconcile all objects again.
-				panic(fmt.Errorf("listting Catalog: %w", err))
+				panic(fmt.Errorf("listting CustomResourceDiscovery: %w", err))
 			}
 			for _, crds := range crdsList.Items {
 				out = append(out, reconcile.Request{

--- a/pkg/manager/internal/webhooks/customresourcediscovery_webhook_test.go
+++ b/pkg/manager/internal/webhooks/customresourcediscovery_webhook_test.go
@@ -40,7 +40,7 @@ func TestCustomResourceDiscoveryValidatingCreate(t *testing.T) {
 			name: "servicecluster missing",
 			object: &corev1alpha1.CustomResourceDiscovery{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-crdiscoveryy",
+					Name:      "test-crdiscovery",
 					Namespace: "test-namespace",
 				},
 				Spec: corev1alpha1.CustomResourceDiscoverySpec{
@@ -56,7 +56,7 @@ func TestCustomResourceDiscoveryValidatingCreate(t *testing.T) {
 			name: "crd missing",
 			object: &corev1alpha1.CustomResourceDiscovery{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-crdiscoveryy",
+					Name:      "test-crdiscovery",
 					Namespace: "test-namespace",
 				},
 				Spec: corev1alpha1.CustomResourceDiscoverySpec{
@@ -72,7 +72,7 @@ func TestCustomResourceDiscoveryValidatingCreate(t *testing.T) {
 			name: "can pass validating create",
 			object: &corev1alpha1.CustomResourceDiscovery{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-crdiscoveryy",
+					Name:      "test-crdiscovery",
 					Namespace: "test-namespace",
 				},
 				Spec: corev1alpha1.CustomResourceDiscoverySpec{
@@ -103,7 +103,7 @@ func TestCustomResourceDiscoveryValidatingUpdate(t *testing.T) {
 
 	oldObj := &corev1alpha1.CustomResourceDiscovery{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-crdiscoveryy",
+			Name:      "test-crdiscovery",
 			Namespace: "test-namespace",
 		},
 		Spec: corev1alpha1.CustomResourceDiscoverySpec{
@@ -126,7 +126,7 @@ func TestCustomResourceDiscoveryValidatingUpdate(t *testing.T) {
 			name: "kind override immutable",
 			object: &corev1alpha1.CustomResourceDiscovery{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-crdiscoveryy",
+					Name:      "test-crdiscovery",
 					Namespace: "test-namespace",
 				},
 				Spec: corev1alpha1.CustomResourceDiscoverySpec{
@@ -145,7 +145,7 @@ func TestCustomResourceDiscoveryValidatingUpdate(t *testing.T) {
 			name: "servicecluster immutable",
 			object: &corev1alpha1.CustomResourceDiscovery{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-crdiscoveryy",
+					Name:      "test-crdiscovery",
 					Namespace: "test-namespace",
 				},
 				Spec: corev1alpha1.CustomResourceDiscoverySpec{
@@ -164,7 +164,7 @@ func TestCustomResourceDiscoveryValidatingUpdate(t *testing.T) {
 			name: "crd immutable",
 			object: &corev1alpha1.CustomResourceDiscovery{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-crdiscoveryy",
+					Name:      "test-crdiscovery",
 					Namespace: "test-namespace",
 				},
 				Spec: corev1alpha1.CustomResourceDiscoverySpec{
@@ -183,7 +183,7 @@ func TestCustomResourceDiscoveryValidatingUpdate(t *testing.T) {
 			name: "can pass validating update",
 			object: &corev1alpha1.CustomResourceDiscovery{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-crdiscoveryy",
+					Name:      "test-crdiscovery",
 					Namespace: "test-namespace",
 				},
 				Spec: corev1alpha1.CustomResourceDiscoverySpec{

--- a/test/provider/servicecluster.go
+++ b/test/provider/servicecluster.go
@@ -118,7 +118,7 @@ func NewServiceClusterSuite(
 		require.NoError(t, testutil.WaitUntilReady(masterClient, serviceCluster))
 
 		// Test CustomResourceDiscoverySet
-		crdiscoveries := &corev1alpha1.CustomResourceDiscoverySet{
+		crDiscoveries := &corev1alpha1.CustomResourceDiscoverySet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "redis",
 				Namespace: provider.Status.NamespaceName,
@@ -130,8 +130,8 @@ func NewServiceClusterSuite(
 				},
 			},
 		}
-		require.NoError(t, masterClient.Create(ctx, crdiscoveries))
-		require.NoError(t, testutil.WaitUntilReady(masterClient, crdiscoveries))
+		require.NoError(t, masterClient.Create(ctx, crDiscoveries))
+		require.NoError(t, testutil.WaitUntilReady(masterClient, crDiscoveries))
 
 		// We have created/registered new CRD's, so we need a new client
 		masterClient, err = f.MasterClient()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR renames `crdiscovery` to `crDiscovery` since it is for `CustomResourceDiscovery`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
