### PR TITLE
Fixing CustomRescourceDiscoverySet deletion

### DIFF
--- a/pkg/manager/internal/controllers/customresourcediscoveryset_controller.go
+++ b/pkg/manager/internal/controllers/customresourcediscoveryset_controller.go
@@ -67,7 +67,7 @@ func (r *CustomResourceDiscoverySetReconciler) Reconcile(req ctrl.Request) (ctrl
 			return ctrl.Result{}, fmt.Errorf("updating CustomResourceDiscoverySet finalizers: %w", err)
 		}
 	}
-	if crDiscoverySet.DeletionTimestamp.IsZero() {
+	if !crDiscoverySet.DeletionTimestamp.IsZero() {
 		// nothing to do, let kube controller-manager foregroundDeletion wait until every created object is deleted
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes CustomRescourceDiscoverySet deletion. It will only be deleted after all its created CustomRescourceDiscovery objects are deleted as well.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #208 

```release-note
NONE
```
