### PR TITLE
Remove the creation of the cert-manager namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,6 @@ install-git-hooks:
 
 # Install cert-manager in the configured Kubernetes cluster
 cert-manager:
-	kubectl create namespace cert-manager || true
 	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.13.0/cert-manager.yaml
 	kubectl wait --for=condition=available deployment/cert-manager -n cert-manager --timeout=120s
 	kubectl wait --for=condition=available deployment/cert-manager-cainjector -n cert-manager --timeout=120s


### PR DESCRIPTION
**What this PR does / why we need it**:
In cert-manager v0.13.0, the `cert-manager` namespace will be created during the `kubectl apply -f  
https://github.com/jetstack/cert-manager/releases/download/v0.13.0/cert-manager.yaml`, thus we can remove the command to create the namespace.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
