### PR TITLE
Remove the watch of the ServiceCluster in the ferry ServiceCluster controller

### DIFF
--- a/pkg/ferry/internal/controllers/servicecluster_controller.go
+++ b/pkg/ferry/internal/controllers/servicecluster_controller.go
@@ -111,26 +111,6 @@ func (r *ServiceClusterReconciler) SetupWithManager(masterMgr ctrl.Manager) erro
 	); err != nil {
 		return fmt.Errorf("initial watch: %w", err)
 	}
-
-	err = c.Watch(
-		&source.Kind{Type: &corev1alpha1.ServiceCluster{}},
-		&handler.EnqueueRequestsFromMapFunc{
-			ToRequests: handler.ToRequestsFunc(func(obj handler.MapObject) []reconcile.Request {
-				if obj.Meta.GetName() == r.ServiceClusterName {
-					return []reconcile.Request{{
-						NamespacedName: types.NamespacedName{
-							Namespace: r.ProviderNamespace,
-							Name:      r.ServiceClusterName,
-						},
-					}}
-				}
-				return nil
-			}),
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("serviceCluster watch: %w", err)
-	}
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously, the ferry ServiceCluster controller watches the `ServiceCluster`, but now since we are managing the Ferry components in the manager ServiceCluster controller, it is problematic:
The problem is an infinite loop of updating status:
ferry ServiceCluster controller update the `status` to `Reachable` -> manger ServiceCluster controller update the `status` to `Ready` -> trigger the ferry SerivceCluster controller update the status -> trigger the manager.....
This can cause some outdated requests in the request queue, and the outdated update requests will fail due to `resourceVersion` is outdated.
```
{"level":"error","ts":1582005788.940304,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"servicecluster-controller","request":"provider-example-cloud/eu-west-1","error":"updateing status: updating status: Operation cannot be fulfilled on serviceclusters.kubecarrier.io \"eu-west-1\": the object has been modified; please apply your changes to the latest version and try again","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/Users/maxwell/go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/Users/maxwell/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.0/pkg/internal/controller/controller.go:258\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/Users/maxwell/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.0/pkg/internal/controller/controller.go:232\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/Users/maxwell/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.0/pkg/internal/controller/controller.go:211\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/Users/maxwell/go/pkg/mod/k8s.io/apimachinery@v0.17.2/pkg/util/wait/wait.go:152\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/Users/maxwell/go/pkg/mod/k8s.io/apimachinery@v0.17.2/pkg/util/wait/wait.go:153\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/Users/maxwell/go/pkg/mod/k8s.io/apimachinery@v0.17.2/pkg/util/wait/wait.go:88"}
```

For solving this problem, the ferry should not watch the `ServiceCluster` anymore, and just enqueue a request for heartbeat at the creation time.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
