### PR TITLE
Add labels to CRDiscovery created CRD

### DIFF
--- a/pkg/manager/internal/controllers/customresourcediscovery_controller.go
+++ b/pkg/manager/internal/controllers/customresourcediscovery_controller.go
@@ -154,6 +154,7 @@ func (r *CustomResourceDiscoveryReconciler) reconcileCRD(
 			Name: plural + "." + group,
 			Labels: map[string]string{
 				"kubecarrier.io/origin-namespace": crDiscovery.Namespace,
+				"kubecarrier.io/service-cluster":  crDiscovery.Spec.ServiceCluster.Name,
 			},
 		},
 		Spec: apiextensionsv1.CustomResourceDefinitionSpec{

--- a/pkg/manager/internal/controllers/customresourcediscovery_controller_test.go
+++ b/pkg/manager/internal/controllers/customresourcediscovery_controller_test.go
@@ -109,6 +109,10 @@ func TestCustomResourceDiscoveryReconciler(t *testing.T) {
 	require.NoError(t, r.Client.Get(ctx, types.NamespacedName{
 		Name: strings.Join([]string{"redis", serviceClusterName, crDiscovery.Namespace}, "."),
 	}, internalCRD))
+	assert.Equal(t, map[string]string{
+		"kubecarrier.io/origin-namespace": crDiscovery.Namespace,
+		"kubecarrier.io/service-cluster":  crDiscovery.Spec.ServiceCluster.Name,
+	}, internalCRD.Labels)
 
 	internalCRD.Status.Conditions = []apiextensionsv1.CustomResourceDefinitionCondition{
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the `kubecarrier.io/service-cluster` label to discovered CRDs, so the CatalogEntry/DerivedCR controller can work with them.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
