### PR TITLE
Implemented go1.14 fixes

### DIFF
--- a/config/dockerfiles/test.Dockerfile
+++ b/config/dockerfiles/test.Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get -qq update && apt-get -qqy install \
 
 RUN curl -fsSL https://get.docker.com | sh
 RUN curl -sL --output /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl && chmod a+x /usr/local/bin/kubectl
-RUN curl -sL https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz | tar -C /usr/local -xz
+RUN curl -sL https://dl.google.com/go/go1.14.linux-amd64.tar.gz | tar -C /usr/local -xz
 ENV PATH=${PATH}:/usr/local/go/bin:/root/go/bin
 RUN go env
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubermatic/kubecarrier
 
-go 1.13
+go 1.14
 
 replace k8s.io/client-go => k8s.io/client-go v0.17.2
 

--- a/pkg/internal/version/version.go
+++ b/pkg/internal/version/version.go
@@ -23,9 +23,13 @@ import (
 	"time"
 )
 
+// https://github.com/golang/go/issues/37369
+const (
+	empty = "was not build properly"
+)
+
 // Values are provided by compile time -ldflags.
 var (
-	empty     = "was not build properly"
 	Version   = empty
 	Branch    = empty
 	Commit    = empty


### PR DESCRIPTION
**What this PR does / why we need it**:

It moves kubecarrier to go 1.14 and implements fixes for different ldflags behavior
```release-note
moved to go 1.14
```
