### PR TITLE
Fixed krew manifest URL for windows

### DIFF
--- a/hack/krew-manifest/main.go
+++ b/hack/krew-manifest/main.go
@@ -73,7 +73,7 @@ func main() {
 			},
 		} {
 			platform := index.Platform{
-				URI: fmt.Sprintf("https://github.com/kubermatic/kubecarrier/releases/download/%s/kubecarrier_%s_%s.tar.gz", *version, os.osName, arch),
+				URI: fmt.Sprintf("https://github.com/kubermatic/kubecarrier/releases/download/%s/kubecarrier_%s_%s%s", *version, os.osName, arch, os.archiveExt),
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"os":   os.osName,


### PR DESCRIPTION
**What this PR does / why we need it**:

As part of the release process, we generated windows download URL with wrong filename extension (`.tar.gz` instead of `.zip`)  This fixes it. 

```release-note
NONE
```
