### PR TITLE
Incresed catalogentrySet timeout in Scenarios/simple e2e test

### DIFF
--- a/test/scenarios/simple.go
+++ b/test/scenarios/simple.go
@@ -158,7 +158,7 @@ func newSimpleScenario(f *testutil.Framework) func(t *testing.T) {
 			},
 		}
 		require.NoError(t, managementClient.Create(ctx, catalogEntrySet))
-		require.NoError(t, testutil.WaitUntilReady(ctx, managementClient, catalogEntrySet))
+		require.NoError(t, testutil.WaitUntilReady(ctx, managementClient, catalogEntrySet, testutil.WithTimeout(time.Minute)))
 
 		internalCRD := &apiextensionsv1.CustomResourceDefinition{}
 		require.NoError(t, managementClient.Get(ctx, types.NamespacedName{


### PR DESCRIPTION
**What this PR does / why we need it**:

Due to prow's cluster slowness, sometimes e2e test are failing on timeout for the CatalogEntrySet operations. This PR increased the timeout to 1 minute from default 30s. 

e.g. https://github.com/kubermatic/kubecarrier/pull/287#issuecomment-598676830

```release-note
NONE
```
