### PR TITLE
propagate deletion error upwards

### DIFF
--- a/pkg/internal/util/object.go
+++ b/pkg/internal/util/object.go
@@ -118,7 +118,7 @@ func DeleteObjects(ctx context.Context, cl client.Client, scheme *runtime.Scheme
 			cleanedUp = false
 		case errors.IsNotFound(err):
 		default:
-			return false, fmt.Errorf("deleting ")
+			return false, fmt.Errorf("deleting %v %w", obj, err)
 		}
 	}
 	return cleanedUp, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Deletion error isn't propagated up the call chain. This PR fixes it.

```release-note
NONE
```
