### PR TITLE
Added account deletion helper

### DIFF
--- a/hack/gen-tasks.go
+++ b/hack/gen-tasks.go
@@ -137,6 +137,7 @@ func main() {
 		"Integration/serviceCluster",
 		"Integration/catalog",
 		"Integration/account",
+		"Integration/cli",
 		"Scenarios",
 		"Scenarios/simple",
 	} {

--- a/pkg/cli/internal/cmd/delete/account.go
+++ b/pkg/cli/internal/cmd/delete/account.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2019 The KubeCarrier Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deletecmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	catalogv1alpha1 "github.com/kubermatic/kubecarrier/pkg/apis/catalog/v1alpha1"
+	corev1alpha1 "github.com/kubermatic/kubecarrier/pkg/apis/core/v1alpha1"
+	"github.com/kubermatic/kubecarrier/pkg/internal/util"
+)
+
+func newAccountCommand(log logr.Logger, cl *util.ClientWatcher) *cobra.Command {
+	var (
+		force bool
+		all   bool
+	)
+	cmd := &cobra.Command{
+		Args:  cobra.MaximumNArgs(1),
+		Use:   "account",
+		Short: "account NAME [--all] [--force]",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if all && len(args) > 0 {
+				return fmt.Errorf("either --all or specific account must be specified")
+			}
+			if !all && len(args) == 0 {
+				return fmt.Errorf("one of --all or specific account must be specified")
+			}
+
+			ctx := context.Background()
+
+			if all {
+				list := &catalogv1alpha1.AccountList{}
+				if err := cl.List(ctx, list); err != nil {
+					return err
+				}
+				for _, it := range list.Items {
+					args = append(args, it.Name)
+				}
+			}
+			for _, it := range args {
+				fmt.Println("deleting account", "name", it)
+				account := &catalogv1alpha1.Account{
+					ObjectMeta: metav1.ObjectMeta{Name: it},
+				}
+				err := cl.Delete(ctx, account)
+				if err != nil {
+					if !force || !strings.HasPrefix(err.Error(), "admission webhook \"vaccount.kubecarrier.io\" denied the request: deletion blocking objects found") {
+						return err
+					}
+
+					for _, objKind := range []runtime.Object{
+						&catalogv1alpha1.CatalogEntrySetList{},
+						&catalogv1alpha1.CatalogEntryList{},
+						&catalogv1alpha1.DerivedCustomResourceList{},
+						&corev1alpha1.CustomResourceDiscoverySetList{},
+						&corev1alpha1.CustomResourceDiscoveryList{},
+						&corev1alpha1.ServiceClusterAssignmentList{},
+					} {
+						if err := cl.List(ctx, objKind, client.InNamespace(account.Status.Namespace.Name)); err != nil {
+							return err
+						}
+						objs, err := meta.ExtractList(objKind)
+						if err != nil {
+							return err
+						}
+						for _, obj := range objs {
+							fmt.Println("deleting", util.MustLogLine(obj, scheme))
+							if err := cl.Delete(ctx, obj); err != nil {
+								return err
+							}
+						}
+						for _, obj := range objs {
+							if err := cl.WaitUntilNotFound(ctx, obj); err != nil {
+								return err
+							}
+						}
+					}
+				}
+				if err := cl.WaitUntilNotFound(ctx, account); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "force delete the account")
+	cmd.Flags().BoolVar(&all, "all", false, "delete all accounts")
+	return cmd
+}

--- a/pkg/cli/internal/cmd/delete/delete.go
+++ b/pkg/cli/internal/cmd/delete/delete.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2019 The KubeCarrier Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deletecmd
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	catalogv1alpha1 "github.com/kubermatic/kubecarrier/pkg/apis/catalog/v1alpha1"
+	corev1alpha1 "github.com/kubermatic/kubecarrier/pkg/apis/core/v1alpha1"
+	operatorv1alpha1 "github.com/kubermatic/kubecarrier/pkg/apis/operator/v1alpha1"
+	"github.com/kubermatic/kubecarrier/pkg/internal/util"
+)
+
+var (
+	scheme = runtime.NewScheme()
+)
+
+func init() {
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+	utilruntime.Must(catalogv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(operatorv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(corev1alpha1.AddToScheme(scheme))
+}
+
+// NewKubecarrierCLI creates the root command for the KubeCarrier CLI.
+func NewDeleteCommand(log logr.Logger) *cobra.Command {
+	flags := genericclioptions.NewConfigFlags(false)
+	var cl = new(util.ClientWatcher)
+
+	cmd := &cobra.Command{
+		Args:  cobra.NoArgs,
+		Use:   "delete",
+		Short: "delete KubeCarrier components",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := flags.ToRESTConfig()
+			if err != nil {
+				return err
+			}
+			clL, err := util.NewClientWatcher(
+				cfg,
+				scheme,
+				log,
+			)
+			if err != nil {
+				return err
+			}
+			*cl = *clL
+			return err
+		},
+	}
+	flags.AddFlags(cmd.PersistentFlags())
+	cmd.AddCommand(newAccountCommand(log, cl))
+	return cmd
+}

--- a/pkg/cli/internal/cmd/root.go
+++ b/pkg/cli/internal/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	deletecmd "github.com/kubermatic/kubecarrier/pkg/cli/internal/cmd/delete"
 	e2e_test "github.com/kubermatic/kubecarrier/pkg/cli/internal/cmd/e2e-test"
 	"github.com/kubermatic/kubecarrier/pkg/cli/internal/cmd/setup"
 	"github.com/kubermatic/kubecarrier/pkg/cli/internal/cmd/sut"
@@ -43,6 +44,7 @@ https://github.com/kubermatic/kubecarrier`,
 		setup.NewCommand(log),
 		version.NewCommand(log),
 		sut.NewCommand(log),
+		deletecmd.NewDeleteCommand(log),
 	)
 
 	return util.CmdLogMixin(cmd)

--- a/test/integration/cli.go
+++ b/test/integration/cli.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2019 The KubeCarrier Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	corev1alpha1 "github.com/kubermatic/kubecarrier/pkg/apis/core/v1alpha1"
+	"github.com/kubermatic/kubecarrier/pkg/testutil"
+)
+
+func newCLI(f *testutil.Framework) func(t *testing.T) {
+	return func(t *testing.T) {
+		testName := strings.Replace(strings.ToLower(t.Name()), "/", "-", -1)
+		ctx := context.Background()
+
+		managementClient, err := f.ManagementClient(t)
+		require.NoError(t, err, "creating management client")
+		t.Cleanup(managementClient.CleanUpFunc(ctx))
+
+		account := f.NewTenantAccount(testName+"-force", rbacv1.Subject{
+			Kind:     rbacv1.GroupKind,
+			APIGroup: "rbac.authorization.k8s.io",
+			Name:     "admin",
+		})
+		require.NoError(t, managementClient.Create(ctx, account))
+		require.NoError(t, testutil.WaitUntilReady(ctx, managementClient, account))
+
+		serviceCluster := f.SetupServiceCluster(ctx, managementClient, t, "eu-west-1", account)
+
+		sca := &corev1alpha1.ServiceClusterAssignment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      account.Status.Namespace.Name + "." + serviceCluster.Name,
+				Namespace: account.Status.Namespace.Name,
+			},
+			Spec: corev1alpha1.ServiceClusterAssignmentSpec{
+				ServiceCluster: corev1alpha1.ObjectReference{
+					Name: serviceCluster.Name,
+				},
+				ManagementClusterNamespace: corev1alpha1.ObjectReference{
+					Name: account.Status.Namespace.Name,
+				},
+			},
+		}
+
+		require.NoError(t, managementClient.Create(ctx, sca))
+		require.NoError(t, testutil.WaitUntilReady(ctx, managementClient, sca))
+		require.Error(t, managementClient.Delete(ctx, account))
+
+		c := exec.CommandContext(ctx, "kubectl", "kubecarrier", "delete", "--kubeconfig", f.Config().ManagementExternalKubeconfigPath, "account", "--force", account.Name)
+		out, err := c.CombinedOutput()
+		t.Log(string(out))
+		require.NoError(t, err)
+
+		require.NoError(t, testutil.WaitUntilNotFound(ctx, managementClient, account, testutil.WithTimeout(5*time.Second)))
+	}
+}

--- a/test/integration/integration.go
+++ b/test/integration/integration.go
@@ -31,6 +31,7 @@ func NewIntegrationSuite(f *testutil.Framework) func(t *testing.T) {
 			"serviceCluster": newServiceClusterSuite,
 			"catalog":        newCatalogSuite,
 			"account":        newAccount,
+			"cli":            newCLI,
 		} {
 			name := name
 			testFn := testFn


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds account deletion helper to the kubecarrier CLI. What's special about is the `--force` flag which basically nukes the account --> cleaning up all deletion blocking objects and destroying the whole account.

```release-note
* added `kubecarrier delete account` CLI helper 
```
