### PR TITLE
disabling CustromResourceDiscovery/DerivedCustromResource deletion webhooks

### DIFF
--- a/pkg/manager/internal/webhooks/customresourcediscovery_webhook.go
+++ b/pkg/manager/internal/webhooks/customresourcediscovery_webhook.go
@@ -20,20 +20,14 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/go-logr/logr"
 	adminv1beta1 "k8s.io/api/admission/v1beta1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	corev1alpha1 "github.com/kubermatic/kubecarrier/pkg/apis/core/v1alpha1"
-	"github.com/kubermatic/kubecarrier/pkg/internal/util"
 )
 
 // CustomResourceDiscoveryWebhookHandler handles mutating/validating of CustomResourceDiscoveries.
@@ -67,13 +61,6 @@ func (r *CustomResourceDiscoveryWebhookHandler) Handle(ctx context.Context, req 
 	case adminv1beta1.Delete:
 		// TODO: FIX THIS!
 		return admission.Allowed("temporary disabled due to bug")
-		oldObj := &corev1alpha1.CustomResourceDiscovery{}
-		if err := r.decoder.DecodeRaw(req.OldObject, oldObj); err != nil {
-			return admission.Errored(http.StatusBadRequest, err)
-		}
-		if err := r.validateDelete(ctx, oldObj); err != nil {
-			return admission.Denied(err.Error())
-		}
 	}
 	return admission.Allowed("allowed to commit the request")
 
@@ -96,37 +83,4 @@ func (r *CustomResourceDiscoveryWebhookHandler) validateUpdate(oldObj, newObj *c
 		return fmt.Errorf("the Spec (ServiceCluster, CRD, and KindOverride) of CustomResourceDiscovery is immutable")
 	}
 	return nil
-}
-
-func (r *CustomResourceDiscoveryWebhookHandler) validateDelete(ctx context.Context, obj *corev1alpha1.CustomResourceDiscovery) error {
-	r.Log.Info("validate delete", "name", obj.Name)
-	if obj.Status.ManagementClusterCRD == nil {
-		return nil
-	}
-
-	crd := &apiextensionsv1.CustomResourceDefinition{}
-	if err := r.Get(ctx, types.NamespacedName{
-		Name: obj.Status.ManagementClusterCRD.Name,
-	}, crd); err != nil {
-		return err
-	}
-	u := &unstructured.UnstructuredList{}
-	u.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   crd.Spec.Group,
-		Version: crd.Spec.Versions[0].Name,
-		Kind:    crd.Spec.Names.ListKind,
-	})
-	if err := r.List(ctx, u); err != nil {
-		return err
-	}
-	if len(u.Items) == 0 {
-		return nil
-	}
-
-	errorMsg := new(strings.Builder)
-	errorMsg.WriteString("management cluster CRD instances are still present in the management cluster\n")
-	for _, it := range u.Items {
-		errorMsg.WriteString(util.MustLogLine(&it, r.Scheme) + " still present\n")
-	}
-	return fmt.Errorf("%s", errorMsg)
 }

--- a/pkg/manager/internal/webhooks/customresourcediscovery_webhook.go
+++ b/pkg/manager/internal/webhooks/customresourcediscovery_webhook.go
@@ -65,6 +65,8 @@ func (r *CustomResourceDiscoveryWebhookHandler) Handle(ctx context.Context, req 
 			return admission.Denied(err.Error())
 		}
 	case adminv1beta1.Delete:
+		// TODO: FIX THIS!
+		return admission.Allowed("temporary disabled due to bug")
 		oldObj := &corev1alpha1.CustomResourceDiscovery{}
 		if err := r.decoder.DecodeRaw(req.OldObject, oldObj); err != nil {
 			return admission.Errored(http.StatusBadRequest, err)

--- a/pkg/manager/internal/webhooks/derivedcustomresource_webhook.go
+++ b/pkg/manager/internal/webhooks/derivedcustomresource_webhook.go
@@ -20,20 +20,14 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/go-logr/logr"
 	adminv1beta1 "k8s.io/api/admission/v1beta1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	catalogv1alpha1 "github.com/kubermatic/kubecarrier/pkg/apis/catalog/v1alpha1"
-	"github.com/kubermatic/kubecarrier/pkg/internal/util"
 )
 
 // DerivedCustomResourceWebhookHandler handles mutating/validating of DerivedCustomResources.
@@ -66,13 +60,6 @@ func (r *DerivedCustomResourceWebhookHandler) Handle(ctx context.Context, req ad
 	case adminv1beta1.Delete:
 		// TODO: FIX THIS!
 		return admission.Allowed("temporary disabled due to bug")
-		oldObj := &catalogv1alpha1.DerivedCustomResource{}
-		if err := r.decoder.DecodeRaw(req.OldObject, oldObj); err != nil {
-			return admission.Errored(http.StatusBadRequest, err)
-		}
-		if err := r.validateDelete(ctx, oldObj); err != nil {
-			return admission.Denied(err.Error())
-		}
 	}
 	return admission.Allowed("allowed to commit the request")
 
@@ -93,36 +80,4 @@ func (r *DerivedCustomResourceWebhookHandler) validateUpdate(oldObj, newObj *cat
 		return fmt.Errorf("the BaseCRD of DerivedCustomResource is immutable")
 	}
 	return nil
-}
-
-func (r *DerivedCustomResourceWebhookHandler) validateDelete(ctx context.Context, obj *catalogv1alpha1.DerivedCustomResource) error {
-	if obj.Status.DerivedCR == nil {
-		return nil
-	}
-
-	crd := &apiextensionsv1.CustomResourceDefinition{}
-	if err := r.Get(ctx, types.NamespacedName{
-		Name: obj.Status.DerivedCR.Name,
-	}, crd); err != nil {
-		return err
-	}
-	u := &unstructured.UnstructuredList{}
-	u.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   crd.Spec.Group,
-		Version: crd.Spec.Versions[0].Name,
-		Kind:    crd.Spec.Names.ListKind,
-	})
-	if err := r.List(ctx, u); err != nil {
-		return err
-	}
-	if len(u.Items) == 0 {
-		return nil
-	}
-
-	errorMsg := new(strings.Builder)
-	errorMsg.WriteString("derived CRD instances are still present in the cluster\n")
-	for _, it := range u.Items {
-		errorMsg.WriteString(util.MustLogLine(&it, r.Scheme) + " still present\n")
-	}
-	return fmt.Errorf("%s", errorMsg)
 }

--- a/pkg/manager/internal/webhooks/derivedcustomresource_webhook.go
+++ b/pkg/manager/internal/webhooks/derivedcustomresource_webhook.go
@@ -64,6 +64,8 @@ func (r *DerivedCustomResourceWebhookHandler) Handle(ctx context.Context, req ad
 			return admission.Denied(err.Error())
 		}
 	case adminv1beta1.Delete:
+		// TODO: FIX THIS!
+		return admission.Allowed("temporary disabled due to bug")
 		oldObj := &catalogv1alpha1.DerivedCustomResource{}
 		if err := r.decoder.DecodeRaw(req.OldObject, oldObj); err != nil {
 			return admission.Errored(http.StatusBadRequest, err)

--- a/test/integration/derivedcr.go
+++ b/test/integration/derivedcr.go
@@ -181,17 +181,18 @@ type: object
 		}
 		require.NoError(t, testutil.WaitUntilFound(ctx, managementClient, providerObj))
 
-		err = managementClient.Delete(ctx, dcr)
-		if assert.Error(t, err,
-			"derived custom resource must not be allowed to delete if derived CRD instances are present",
-		) {
-			assert.Contains(
-				t,
-				err.Error(),
-				"derived CRD instances are still present in the cluster",
-				"derivedCR deletion webhook should error out on derived CRD instance presence",
-			)
-		}
+		// TODO: Fix this
+		//err = managementClient.Delete(ctx, dcr)
+		//if assert.Error(t, err,
+		//	"derived custom resource must not be allowed to delete if derived CRD instances are present",
+		//) {
+		//	assert.Contains(
+		//		t,
+		//		err.Error(),
+		//		"derived CRD instances are still present in the cluster",
+		//		"derivedCR deletion webhook should error out on derived CRD instance presence",
+		//	)
+		//}
 
 		// Check Provider -> Tenant
 		providerObj2 := &unstructured.Unstructured{

--- a/test/integration/servicecluster.go
+++ b/test/integration/servicecluster.go
@@ -219,17 +219,18 @@ ServiceClusterAssignment.kubecarrier.io/v1alpha1: %s.eu-west-1
 		}
 		require.NoError(t, managementClient.Create(ctx, managementClusterObj))
 
-		err = managementClient.Delete(ctx, customResourceDiscovery)
-		if assert.Error(t, err,
-			"CRDiscovery object must not be allowed to delete if ManagementClusterCRD instances are present",
-		) {
-			assert.Contains(
-				t,
-				err.Error(),
-				"management cluster CRD instances are still present in the management cluster",
-				"CRDiscovery deletion webhook should error out on ManagementClusterCRD instance presence",
-			)
-		}
+		// TODO: fix this
+		//err = managementClient.Delete(ctx, customResourceDiscovery)
+		//if assert.Error(t, err,
+		//	"CRDiscovery object must not be allowed to delete if ManagementClusterCRD instances are present",
+		//) {
+		//	assert.Contains(
+		//		t,
+		//		err.Error(),
+		//		"management cluster CRD instances are still present in the management cluster",
+		//		"CRDiscovery deletion webhook should error out on ManagementClusterCRD instance presence",
+		//	)
+		//}
 
 		// a object on the service cluster should have been created
 		serviceClusterObj := &unstructured.Unstructured{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR disabled CustromResourceDiscovery/DerivedCustromResource deletion webhooks due to their buggy behavior.

```release-note
* disabled CustromResourceDiscovery/DerivedCustromResource deletion webhooks
```
