### PR TITLE
Fix conflicting cluster role names for same named catapult & elevator

### DIFF
--- a/pkg/internal/resources/catapult/catapult.go
+++ b/pkg/internal/resources/catapult/catapult.go
@@ -24,6 +24,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/kustomize/v3/pkg/image"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
@@ -66,7 +67,7 @@ func Manifests(c Config) ([]unstructured.Unstructured, error) {
 				NewTag: v.Version,
 			},
 		},
-		Resources: []string{"../default", "aggregation-manager-role.yaml"},
+		Resources: []string{"../default"},
 		PatchesStrategicMerge: []types.PatchStrategicMerge{
 			"manager_env_patch.yaml",
 		},
@@ -200,33 +201,6 @@ func Manifests(c Config) ([]unstructured.Unstructured, error) {
 		return nil, fmt.Errorf("writing /rbac/cluster_role.yaml: %w", err)
 	}
 
-	aggregationManagerRole := rbacv1.ClusterRole{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "rbac.authorization.k8s.io/v1",
-			Kind:       "ClusterRole",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "view-only",
-			Labels: map[string]string{
-				"kubecarrier.io/manager": "true",
-			},
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{c.ManagementClusterGroup},
-				Resources: []string{c.ManagementClusterPlural},
-				Verbs:     []string{"get", "list", "watch"},
-			},
-		},
-	}
-	roleBytes, err = yaml.Marshal(aggregationManagerRole)
-	if err != nil {
-		return nil, fmt.Errorf("marshalling aggreation manager cluster role: %w", err)
-	}
-	if err := kc.WriteFile("/man/aggregation-manager-role.yaml", roleBytes); err != nil {
-		return nil, fmt.Errorf("writing /man/aggregation-manager-role.yaml: %w", err)
-	}
-
 	failurePolicyFail := adminv1beta1.Fail
 	sideEffectsDryRun := adminv1beta1.SideEffectClassNoneOnDryRun
 	mutatingWebhookConfiguration := adminv1beta1.MutatingWebhookConfiguration{
@@ -279,6 +253,31 @@ func Manifests(c Config) ([]unstructured.Unstructured, error) {
 	if err != nil {
 		return nil, fmt.Errorf("running kustomize build: %w", err)
 	}
+
+	rootManagerRole := &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "ClusterRole",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: c.ManagementClusterPlural + "." + c.ManagementClusterGroup + "-view-only",
+			Labels: map[string]string{
+				"kubecarrier.io/manager": "true",
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{c.ManagementClusterGroup},
+				Resources: []string{c.ManagementClusterPlural},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+		},
+	}
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(rootManagerRole)
+	if err != nil {
+		return nil, fmt.Errorf("converting to unstructured: %w", err)
+	}
+	objects = append(objects, unstructured.Unstructured{Object: obj})
 
 	for _, obj := range objects {
 		labels := obj.GetLabels()

--- a/pkg/internal/resources/catapult/catapult.golden.yaml
+++ b/pkg/internal/resources/catapult/catapult.golden.yaml
@@ -350,7 +350,7 @@
       app.kubernetes.io/name: catapult
       app.kubernetes.io/version: was not build properly
       kubecarrier.io/manager: "true"
-    name: db-eu-west-1-view-only
+    name: couchdbinternals.eu-west-1.provider-view-only
   rules:
   - apiGroups:
     - eu-west-1.provider

--- a/pkg/internal/resources/elevator/elevator.golden.yaml
+++ b/pkg/internal/resources/elevator/elevator.golden.yaml
@@ -359,7 +359,7 @@
       app.kubernetes.io/name: elevator
       app.kubernetes.io/version: was not build properly
       kubecarrier.io/manager: "true"
-    name: db-eu-west-1-view-only
+    name: couchdbs.eu-west-1.provider-view-only
   rules:
   - apiGroups:
     - eu-west-1.provider

--- a/pkg/manager/internal/webhooks/customresourcediscovery_webhook.go
+++ b/pkg/manager/internal/webhooks/customresourcediscovery_webhook.go
@@ -20,14 +20,20 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/go-logr/logr"
 	adminv1beta1 "k8s.io/api/admission/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	corev1alpha1 "github.com/kubermatic/kubecarrier/pkg/apis/core/v1alpha1"
+	"github.com/kubermatic/kubecarrier/pkg/internal/util"
 )
 
 // CustomResourceDiscoveryWebhookHandler handles mutating/validating of CustomResourceDiscoveries.
@@ -59,8 +65,13 @@ func (r *CustomResourceDiscoveryWebhookHandler) Handle(ctx context.Context, req 
 			return admission.Denied(err.Error())
 		}
 	case adminv1beta1.Delete:
-		// TODO: FIX THIS!
-		return admission.Allowed("temporary disabled due to bug")
+		oldObj := &corev1alpha1.CustomResourceDiscovery{}
+		if err := r.decoder.DecodeRaw(req.OldObject, oldObj); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		if err := r.validateDelete(ctx, oldObj); err != nil {
+			return admission.Denied(err.Error())
+		}
 	}
 	return admission.Allowed("allowed to commit the request")
 
@@ -83,4 +94,37 @@ func (r *CustomResourceDiscoveryWebhookHandler) validateUpdate(oldObj, newObj *c
 		return fmt.Errorf("the Spec (ServiceCluster, CRD, and KindOverride) of CustomResourceDiscovery is immutable")
 	}
 	return nil
+}
+
+func (r *CustomResourceDiscoveryWebhookHandler) validateDelete(ctx context.Context, obj *corev1alpha1.CustomResourceDiscovery) error {
+	r.Log.Info("validate delete", "name", obj.Name)
+	if obj.Status.ManagementClusterCRD == nil {
+		return nil
+	}
+
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Name: obj.Status.ManagementClusterCRD.Name,
+	}, crd); err != nil {
+		return err
+	}
+	u := &unstructured.UnstructuredList{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   crd.Spec.Group,
+		Version: crd.Spec.Versions[0].Name,
+		Kind:    crd.Spec.Names.ListKind,
+	})
+	if err := r.List(ctx, u); err != nil {
+		return err
+	}
+	if len(u.Items) == 0 {
+		return nil
+	}
+
+	errorMsg := new(strings.Builder)
+	errorMsg.WriteString("management cluster CRD instances are still present in the management cluster\n")
+	for _, it := range u.Items {
+		errorMsg.WriteString(util.MustLogLine(&it, r.Scheme) + " still present\n")
+	}
+	return fmt.Errorf("%s", errorMsg)
 }

--- a/pkg/manager/internal/webhooks/derivedcustomresource_webhook.go
+++ b/pkg/manager/internal/webhooks/derivedcustomresource_webhook.go
@@ -20,14 +20,20 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/go-logr/logr"
 	adminv1beta1 "k8s.io/api/admission/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	catalogv1alpha1 "github.com/kubermatic/kubecarrier/pkg/apis/catalog/v1alpha1"
+	"github.com/kubermatic/kubecarrier/pkg/internal/util"
 )
 
 // DerivedCustomResourceWebhookHandler handles mutating/validating of DerivedCustomResources.
@@ -58,8 +64,13 @@ func (r *DerivedCustomResourceWebhookHandler) Handle(ctx context.Context, req ad
 			return admission.Denied(err.Error())
 		}
 	case adminv1beta1.Delete:
-		// TODO: FIX THIS!
-		return admission.Allowed("temporary disabled due to bug")
+		oldObj := &catalogv1alpha1.DerivedCustomResource{}
+		if err := r.decoder.DecodeRaw(req.OldObject, oldObj); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		if err := r.validateDelete(ctx, oldObj); err != nil {
+			return admission.Denied(err.Error())
+		}
 	}
 	return admission.Allowed("allowed to commit the request")
 
@@ -80,4 +91,36 @@ func (r *DerivedCustomResourceWebhookHandler) validateUpdate(oldObj, newObj *cat
 		return fmt.Errorf("the BaseCRD of DerivedCustomResource is immutable")
 	}
 	return nil
+}
+
+func (r *DerivedCustomResourceWebhookHandler) validateDelete(ctx context.Context, obj *catalogv1alpha1.DerivedCustomResource) error {
+	if obj.Status.DerivedCR == nil {
+		return nil
+	}
+
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Name: obj.Status.DerivedCR.Name,
+	}, crd); err != nil {
+		return err
+	}
+	u := &unstructured.UnstructuredList{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   crd.Spec.Group,
+		Version: crd.Spec.Versions[0].Name,
+		Kind:    crd.Spec.Names.ListKind,
+	})
+	if err := r.List(ctx, u); err != nil {
+		return err
+	}
+	if len(u.Items) == 0 {
+		return nil
+	}
+
+	errorMsg := new(strings.Builder)
+	errorMsg.WriteString("derived CRD instances are still present in the cluster\n")
+	for _, it := range u.Items {
+		errorMsg.WriteString(util.MustLogLine(&it, r.Scheme) + " still present\n")
+	}
+	return fmt.Errorf("%s", errorMsg)
 }

--- a/test/integration/servicecluster.go
+++ b/test/integration/servicecluster.go
@@ -219,18 +219,17 @@ ServiceClusterAssignment.kubecarrier.io/v1alpha1: %s.eu-west-1
 		}
 		require.NoError(t, managementClient.Create(ctx, managementClusterObj))
 
-		// TODO: fix this
-		//err = managementClient.Delete(ctx, customResourceDiscovery)
-		//if assert.Error(t, err,
-		//	"CRDiscovery object must not be allowed to delete if ManagementClusterCRD instances are present",
-		//) {
-		//	assert.Contains(
-		//		t,
-		//		err.Error(),
-		//		"management cluster CRD instances are still present in the management cluster",
-		//		"CRDiscovery deletion webhook should error out on ManagementClusterCRD instance presence",
-		//	)
-		//}
+		err = managementClient.Delete(ctx, customResourceDiscovery)
+		if assert.Error(t, err,
+			"CRDiscovery object must not be allowed to delete if ManagementClusterCRD instances are present",
+		) {
+			assert.Contains(
+				t,
+				err.Error(),
+				"management cluster CRD instances are still present in the management cluster",
+				"CRDiscovery deletion webhook should error out on ManagementClusterCRD instance presence",
+			)
+		}
 
 		// a object on the service cluster should have been created
 		serviceClusterObj := &unstructured.Unstructured{


### PR DESCRIPTION
**What this PR does / why we need it**:

CatalogEntrySet, in the end, creates same-named Elevator & Catapult instances, which create the same-named & conflicting cluster roles for manager's view permissions & webhooks. 

This fixes the issue

```release-note
* reenabled CustromResourceDefinition/DerivedCustomResource webhooks
```
