### PR TITLE
Fix watcher.Stop() on a nil watcher

### DIFF
--- a/pkg/apiserver/internal/v1/offering.go
+++ b/pkg/apiserver/internal/v1/offering.go
@@ -107,10 +107,10 @@ func (o offeringServer) Watch(req *v1.WatchRequest, stream v1.OfferingService_Wa
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
 	watcher, err := o.dynamicClient.Resource(o.gvr).Namespace(req.Account).Watch(listOptions)
-	defer watcher.Stop()
 	if err != nil {
 		return status.Errorf(codes.Internal, "watching offerings: %s", err.Error())
 	}
+	defer watcher.Stop()
 	for {
 		select {
 		case <-stream.Context().Done():


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the bug that running `watcher.Stop()` on a nil watcher if the creation of the watcher returns non-nil error.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
