### PR TITLE
fixed JSON REST API calls skipping gRPC middlewares

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -236,12 +236,12 @@ func runE(flags *flags, log logr.Logger) error {
 
 	accountServer := v1.NewAccountServiceServer(accountClient)
 	apiserverv1.RegisterAccountServiceServer(grpcServer, accountServer)
-	if err := apiserverv1.RegisterAccountServiceHandlerServer(ctx, grpcGatewayMux, accountServer); err != nil {
+	if err := apiserverv1.RegisterAccountServiceHandler(ctx, grpcGatewayMux, grpcClient); err != nil {
 		return err
 	}
 
 	apiserverv1.RegisterKubeCarrierServer(grpcServer, &v1.KubeCarrierServer{})
-	if err := apiserverv1.RegisterKubeCarrierHandlerServer(ctx, grpcGatewayMux, &v1.KubeCarrierServer{}); err != nil {
+	if err := apiserverv1.RegisterKubeCarrierHandler(ctx, grpcGatewayMux, grpcClient); err != nil {
 		return err
 	}
 	offeringServer, err := v1.NewOfferingServiceServer(c, dynamicClient, mapper, scheme)
@@ -255,18 +255,18 @@ func runE(flags *flags, log logr.Logger) error {
 
 	instanceServer := v1.NewInstancesServer(c, mapper)
 	apiserverv1.RegisterInstancesServiceServer(grpcServer, instanceServer)
-	if err := apiserverv1.RegisterInstancesServiceHandlerServer(ctx, grpcGatewayMux, instanceServer); err != nil {
+	if err := apiserverv1.RegisterInstancesServiceHandler(ctx, grpcGatewayMux, grpcClient); err != nil {
 		return err
 	}
 
 	regionServer := v1.NewRegionServiceServer(c)
 	apiserverv1.RegisterRegionServiceServer(grpcServer, regionServer)
-	if err := apiserverv1.RegisterRegionServiceHandlerServer(ctx, grpcGatewayMux, regionServer); err != nil {
+	if err := apiserverv1.RegisterRegionServiceHandler(ctx, grpcGatewayMux, grpcClient); err != nil {
 		return err
 	}
 	providerServer := v1.NewProviderServiceServer(c)
 	apiserverv1.RegisterProviderServiceServer(grpcServer, providerServer)
-	if err := apiserverv1.RegisterProviderServiceHandlerServer(ctx, grpcGatewayMux, providerServer); err != nil {
+	if err := apiserverv1.RegisterProviderServiceHandler(ctx, grpcGatewayMux, grpcClient); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

when using the JSON REST API calls to our API server it skips the gRPC server middlewares handling auth & other goodies. This PR fixes it 

```release-note
NONE
```
