### PR TITLE
moved prow e2e jobs to guaranteed QoS

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -101,7 +101,10 @@ presubmits:
           resources:
             requests:
               cpu: 5
-              memory: 4Gi
+              memory: 8Gi
+            limits:
+              memory: 8Gi
+              cpu: 5
   - name: pull-kubecarrier-e2e-v1.16
     always_run: true
     decorate: true
@@ -147,7 +150,10 @@ presubmits:
           resources:
             requests:
               cpu: 5
-              memory: 4Gi
+              memory: 8Gi
+            limits:
+              memory: 8Gi
+              cpu: 5
 postsubmits:
   - name: post-kubecarrier-test-image
     decorate: true


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR sets prow e2e jobs into guaranteed QoS, ensuring greater replicability for our e2e test runs. Hopefully, this would also ensure greater stability in our e2e tests.

Since the CPU number is an integer, we should also be allocated dedicated CPU cores for the prow e2e job, reducing caching poisoning from other running jobs. 

```release-note
NONE
```
