### PR TITLE
[WIP] Added client watcher soft & hard limits

### DIFF
--- a/hack/gen-tasks.go
+++ b/hack/gen-tasks.go
@@ -147,7 +147,7 @@ func main() {
 		"InstallationSuite",
 		"Integration",
 		"Integration/account",
-		"Integration/api-server",
+		"Integration/apiserver",
 		"Integration/catalog",
 		"Integration/cli",
 		"Integration/derivedCR",

--- a/pkg/internal/util/clientwatcher.go
+++ b/pkg/internal/util/clientwatcher.go
@@ -19,6 +19,7 @@ package util
 import (
 	"context"
 	"fmt"
+	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -134,6 +135,10 @@ func (cw *ClientWatcher) init(ctx context.Context, obj runtime.Object, options [
 //
 // condition function should operate on the passed object in a closure and should not modify the obj
 func (cw *ClientWatcher) WaitUntil(ctx context.Context, obj runtime.Object, cond func() (done bool, err error), options ...ClientWatcherOption) error {
+	if t := ctx.Value(testingKey); t != nil {
+		t.(*testing.T).Helper()
+	}
+
 	ctx, closeFn, err := cw.init(ctx, obj, options)
 	if err != nil {
 		return err
@@ -176,6 +181,9 @@ func (cw *ClientWatcher) WaitUntil(ctx context.Context, obj runtime.Object, cond
 
 // WaitUntilNotFound waits until the object is not found or the context deadline is exceeded
 func (cw *ClientWatcher) WaitUntilNotFound(ctx context.Context, obj runtime.Object, options ...ClientWatcherOption) error {
+	if t := ctx.Value(testingKey); t != nil {
+		t.(*testing.T).Helper()
+	}
 	ctx, closeFn, err := cw.init(ctx, obj, options)
 	if err != nil {
 		return err

--- a/pkg/internal/util/clientwatcher.go
+++ b/pkg/internal/util/clientwatcher.go
@@ -45,7 +45,7 @@ func (opt *clientWatcherOption) Defaults() {
 	}
 
 	if opt.hardTimeout == 0 {
-		opt.hardTimeout = 10 * opt.softTimeout
+		opt.hardTimeout = 2 * opt.softTimeout
 	}
 }
 

--- a/pkg/internal/util/clientwatcher.go
+++ b/pkg/internal/util/clientwatcher.go
@@ -65,13 +65,6 @@ func WithClientWatcherHardTimeout(t time.Duration) ClientWatcherOption {
 	}
 }
 
-func WithoutClientWatcher() ClientWatcherOption {
-	return func(option *clientWatcherOption) error {
-		option.softTimeout = time.Duration(0)
-		return nil
-	}
-}
-
 const (
 	defaultTimeout = 30 * time.Second
 )

--- a/pkg/internal/util/logging.go
+++ b/pkg/internal/util/logging.go
@@ -14,20 +14,32 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package testutil
+package util
 
 import (
-	"testing"
+	"context"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
-func TestLoggerOutput(t *testing.T) {
-	l := NewLogger(t)
+type contextKey string
 
-	g := l.WithName("a").WithName("b").WithValues("c", "d")
-	g.Info("msg")
-	require.Equal(t, []string{"a", "b"}, g.(*Logger).names)
-	assert.Equal(t, "d", g.(*Logger).values["c"])
+const loggerKey contextKey = "logger"
+
+func InjectLogger(ctx context.Context, logger *zap.Logger) context.Context {
+	return context.WithValue(ctx, loggerKey, logger)
+}
+func ExtractLoggerFromContext(ctx context.Context) *zap.Logger {
+	logger := ctx.Value(loggerKey)
+	if logger != nil {
+		return logger.(*zap.Logger)
+	}
+	if ZapLogger != nil {
+		return ZapLogger
+	}
+	l, err := zap.NewDevelopment()
+	if err != nil {
+		panic(err)
+	}
+	return l
 }

--- a/pkg/internal/util/testing.go
+++ b/pkg/internal/util/testing.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2019 The KubeCarrier Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"testing"
+)
+
+const testingKey contextKey = "logger"
+
+func InjectTesting(ctx context.Context, t *testing.T) context.Context {
+	return context.WithValue(ctx, testingKey, t)
+}

--- a/pkg/testutil/framework.go
+++ b/pkg/testutil/framework.go
@@ -160,6 +160,7 @@ func (f *Framework) ManagementClient(t *testing.T, options ...func(config *restc
 }
 
 func (f *Framework) ServiceClient(t *testing.T, options ...func(config *restclient.Config) error) (*RecordingClient, error) {
+	t.Helper()
 	cfg := *f.serviceConfig
 	for _, f := range options {
 		if err := f(&cfg); err != nil {
@@ -174,6 +175,7 @@ func (f *Framework) ServiceClient(t *testing.T, options ...func(config *restclie
 }
 
 func (f *Framework) SetupServiceCluster(ctx context.Context, cl *RecordingClient, t *testing.T, name string, account *catalogv1alpha1.Account) *corev1alpha1.ServiceCluster {
+	t.Helper()
 	// Setup
 	serviceKubeconfig, err := ioutil.ReadFile(f.Config().ServiceInternalKubeconfigPath)
 	require.NoError(t, err, "cannot read service internal kubeconfig")

--- a/pkg/testutil/logger.go
+++ b/pkg/testutil/logger.go
@@ -54,6 +54,7 @@ func NewZapLogger(t *testing.T) *zap.Logger {
 func LoggingContext(t *testing.T, ctx context.Context) (context.Context, *zap.Logger) {
 	logger := NewZapLogger(t)
 	ctx = util.InjectLogger(ctx, logger)
+	ctx = util.InjectTesting(ctx, t)
 	ctx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
 	return ctx, logger

--- a/test/integration/account.go
+++ b/test/integration/account.go
@@ -37,8 +37,7 @@ import (
 func newAccount(f *testutil.Framework) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Log("testing how account handles tenants")
-		ctx, cancel := context.WithCancel(context.Background())
-		t.Cleanup(cancel)
+		ctx, _ := testutil.LoggingContext(t, context.Background())
 		managementClient, err := f.ManagementClient(t)
 		require.NoError(t, err, "creating management client")
 		t.Cleanup(managementClient.CleanUpFunc(ctx))

--- a/test/integration/apiserver.go
+++ b/test/integration/apiserver.go
@@ -684,7 +684,7 @@ func offeringService(ctx context.Context, conn *grpc.ClientConn, managementClien
 		require.NoError(t, managementClient.Create(ctx, offering2))
 
 		client := apiserverv1.NewOfferingServiceClient(conn)
-		offeringCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		offeringCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 		t.Cleanup(cancel)
 		// list offerings with limit and continuation token.
 		require.NoError(t, wait.PollUntil(time.Second, func() (done bool, err error) {

--- a/test/integration/apiserver.go
+++ b/test/integration/apiserver.go
@@ -56,8 +56,7 @@ import (
 func newAPIServer(f *testutil.Framework) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Log("testing how API Server works")
-		ctx, cancel := context.WithCancel(context.Background())
-		t.Cleanup(cancel)
+		ctx, _ := testutil.LoggingContext(t, context.Background())
 		managementClient, err := f.ManagementClient(t)
 		require.NoError(t, err, "creating management client")
 		t.Cleanup(managementClient.CleanUpFunc(ctx))
@@ -135,7 +134,7 @@ func newAPIServer(f *testutil.Framework) func(t *testing.T) {
 		require.NoError(t, managementClient.Create(ctx, apiServer))
 		require.NoError(t, testutil.WaitUntilReady(ctx, managementClient, apiServer))
 
-		ctx, cancel = context.WithCancel(ctx)
+		ctx, cancel := context.WithCancel(ctx)
 		t.Cleanup(cancel)
 
 		pfCmd := exec.CommandContext(ctx,

--- a/test/integration/catalog.go
+++ b/test/integration/catalog.go
@@ -39,8 +39,7 @@ func newCatalogSuite(
 	f *testutil.Framework,
 ) func(t *testing.T) {
 	return func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		t.Cleanup(cancel)
+		ctx, _ := testutil.LoggingContext(t, context.Background())
 		managementClient, err := f.ManagementClient(t)
 		require.NoError(t, err, "creating management client")
 		t.Cleanup(managementClient.CleanUpFunc(ctx))

--- a/test/integration/cli.go
+++ b/test/integration/cli.go
@@ -34,7 +34,7 @@ import (
 func newCLI(f *testutil.Framework) func(t *testing.T) {
 	return func(t *testing.T) {
 		testName := strings.Replace(strings.ToLower(t.Name()), "/", "-", -1)
-		ctx := context.Background()
+		ctx, _ := testutil.LoggingContext(t, context.Background())
 
 		managementClient, err := f.ManagementClient(t)
 		require.NoError(t, err, "creating management client")

--- a/test/integration/derivedcr.go
+++ b/test/integration/derivedcr.go
@@ -41,10 +41,9 @@ func newDerivedCR(
 	f *testutil.Framework,
 ) func(t *testing.T) {
 	return func(t *testing.T) {
+		ctx, _ := testutil.LoggingContext(t, context.Background())
 		managementClient, err := f.ManagementClient(t)
 		require.NoError(t, err, "creating management client")
-		ctx, cancel := context.WithCancel(context.Background())
-		t.Cleanup(cancel)
 		t.Cleanup(managementClient.CleanUpFunc(ctx))
 
 		testName := strings.Replace(strings.ToLower(t.Name()), "/", "-", -1)

--- a/test/integration/fakedb.go
+++ b/test/integration/fakedb.go
@@ -31,8 +31,7 @@ import (
 func newFakeDB(f *testutil.Framework) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Log("testing if we can create FakeDB in service cluster")
-		ctx, cancel := context.WithCancel(context.Background())
-		t.Cleanup(cancel)
+		ctx, _ := testutil.LoggingContext(t, context.Background())
 		serviceClient, err := f.ServiceClient(t)
 		require.NoError(t, err, "creating service client")
 		t.Cleanup(serviceClient.CleanUpFunc(ctx))

--- a/test/integration/servicecluster.go
+++ b/test/integration/servicecluster.go
@@ -43,8 +43,7 @@ func newServiceClusterSuite(
 	f *testutil.Framework,
 ) func(t *testing.T) {
 	return func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		t.Cleanup(cancel)
+		ctx, _ := testutil.LoggingContext(t, context.Background())
 		managementClient, err := f.ManagementClient(t)
 		require.NoError(t, err, "creating management client")
 		t.Cleanup(managementClient.CleanUpFunc(ctx))

--- a/test/scenarios/simple.go
+++ b/test/scenarios/simple.go
@@ -42,8 +42,7 @@ import (
 func newSimpleScenario(f *testutil.Framework) func(t *testing.T) {
 	return func(t *testing.T) {
 		// Setup
-		ctx, cancel := context.WithCancel(context.Background())
-		t.Cleanup(cancel)
+		ctx, _ := testutil.LoggingContext(t, context.Background())
 
 		managementClient, err := f.ManagementClient(t)
 		require.NoError(t, err, "creating management client")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extends ClientWatcher logging during the tests:
* The previous watch limit, is a soft one. If the operation uses more time than the soft limit, a warning is logged
* The hard limit still exists, and it's 2x the soft limit by default
* The operation times are logged
* The logger is overhauled to support those operations, as well as leveling, etc. 

All this is aimed at improving our e2e test pipelines, that is easier debugging what went wrong. Soft time limit hitting is an indicator it should be enlarged, the hard limit is in place for preventing infinite wait time. The time duration logging provides insight into how long each operation takes. 


```release-note
NONE
```
