### PR TITLE
Removed unnecessary logging

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -294,7 +294,6 @@ func runE(flags *flags, log logr.Logger) error {
 	}
 
 	var handler http.Handler = http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		log.Info("got request for", "path", request.URL.Path)
 		if strings.Contains(request.Header.Get("Content-Type"), "application/grpc") {
 			wrappedGrpc.ServeHTTP(writer, request)
 		} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
It removes rendundant logging. Due to gRPC logging middleware, it shall handle the proper request logging, together with the returned status code. 

```release-note
NONE
```
