### PR TITLE
move validate-prow-yaml job to infra repo

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,24 +1,4 @@
 presubmits:
-  - name: pull-kubermatic-kubecarrier-validate-prow-yaml
-    always_run: true
-    decorate: true
-    clone_uri: ssh://git@github.com/kubermatic/kubecarrier.git
-    extra_refs:
-      - org: kubermatic
-        repo: infra
-        base_ref: master
-        clone_uri: git@github.com:kubermatic/infra.git
-    spec:
-      containers:
-        - image: gcr.io/k8s-prow/checkconfig:v20200203-711d3732b
-          command:
-            - /app/prow/cmd/checkconfig/app.binary
-          args:
-            - --plugin-config=/home/prow/go/src/github.com/kubermatic/infra/prow/plugins.yaml
-            - --config-path=/home/prow/go/src/github.com/kubermatic/infra/prow/config.yaml
-            - --job-config-path=/home/prow/go/src/github.com/kubermatic/infra/prow/jobs
-            - --prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)
-
   - name: pull-kubecarrier-test
     always_run: true
     decorate: true


### PR DESCRIPTION
**What this PR does / why we need it**:
All prow validation jobs are kept in the infra repository, because this makes Prow updates much easier. It also makes it so that the prow validation is always mandatory and run before anything else from the in-repo config is even looked at. That is a nice security feature we want to keep, hence this PR moves the job into the infra repo.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
