### PR TITLE
Fix customResourceDiscoverySet controller

### DIFF
--- a/pkg/manager/internal/controllers/catalogentryset_controller.go
+++ b/pkg/manager/internal/controllers/catalogentryset_controller.go
@@ -117,7 +117,7 @@ func (r *CatalogEntrySetReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 	catalogEntryList := &catalogv1alpha1.CatalogEntryList{}
 	if err := r.List(ctx, catalogEntryList, client.MatchingLabels{
 		catalogEntriesLabel: catalogEntrySet.Name,
-	}); err != nil {
+	}, client.InNamespace(catalogEntrySet.Namespace)); err != nil {
 		return ctrl.Result{}, fmt.Errorf(
 			"listing all CatalogEntry for this CatalogEntrySet: %w", err)
 	}

--- a/pkg/manager/internal/controllers/customresourcediscoveryset_controller.go
+++ b/pkg/manager/internal/controllers/customresourcediscoveryset_controller.go
@@ -116,8 +116,10 @@ func (r *CustomResourceDiscoverySetReconciler) Reconcile(req ctrl.Request) (ctrl
 	// Cleanup uncontrolled CRDiscoveries
 	crDiscoveryList := &corev1alpha1.CustomResourceDiscoveryList{}
 	if err := r.List(ctx, crDiscoveryList, client.MatchingLabels{
-		crDiscoveriesLabel: crDiscoverySet.Name,
-	}); err != nil {
+		crDiscoveriesLabel: crDiscoverySet.Namespace + "/" + crDiscoverySet.Name,
+	},
+		client.InNamespace(crDiscoverySet.Namespace),
+	); err != nil {
 		return result, fmt.Errorf(
 			"listing all CustomResourceDiscovery for this Set: %w", err)
 	}
@@ -170,7 +172,7 @@ func (r *CustomResourceDiscoverySetReconciler) reconcileCRDiscovery(
 			Name:      crDiscoverySet.Name + "." + serviceCluster.Name,
 			Namespace: crDiscoverySet.Namespace,
 			Labels: map[string]string{
-				crDiscoveriesLabel: crDiscoverySet.Name,
+				crDiscoveriesLabel: crDiscoverySet.Namespace + "/" + crDiscoverySet.Name,
 			},
 		},
 		Spec: corev1alpha1.CustomResourceDiscoverySpec{

--- a/pkg/manager/internal/controllers/customresourcediscoveryset_controller.go
+++ b/pkg/manager/internal/controllers/customresourcediscoveryset_controller.go
@@ -116,7 +116,7 @@ func (r *CustomResourceDiscoverySetReconciler) Reconcile(req ctrl.Request) (ctrl
 	// Cleanup uncontrolled CRDiscoveries
 	crDiscoveryList := &corev1alpha1.CustomResourceDiscoveryList{}
 	if err := r.List(ctx, crDiscoveryList, client.MatchingLabels{
-		crDiscoveriesLabel: crDiscoverySet.Namespace + "/" + crDiscoverySet.Name,
+		crDiscoveriesLabel: crDiscoverySet.Namespace + "." + crDiscoverySet.Name,
 	},
 		client.InNamespace(crDiscoverySet.Namespace),
 	); err != nil {
@@ -172,7 +172,7 @@ func (r *CustomResourceDiscoverySetReconciler) reconcileCRDiscovery(
 			Name:      crDiscoverySet.Name + "." + serviceCluster.Name,
 			Namespace: crDiscoverySet.Namespace,
 			Labels: map[string]string{
-				crDiscoveriesLabel: crDiscoverySet.Namespace + "/" + crDiscoverySet.Name,
+				crDiscoveriesLabel: crDiscoverySet.Namespace + "." + crDiscoverySet.Name,
 			},
 		},
 		Spec: corev1alpha1.CustomResourceDiscoverySpec{

--- a/pkg/manager/internal/controllers/customresourcediscoveryset_controller_test.go
+++ b/pkg/manager/internal/controllers/customresourcediscoveryset_controller_test.go
@@ -69,7 +69,7 @@ func TestCustomResourceDiscoverySetReconciler(t *testing.T) {
 			Name:      "couchdb.us-east-1",
 			Namespace: "hans",
 			Labels: map[string]string{
-				crDiscoveriesLabel: crDiscoveries.Name,
+				crDiscoveriesLabel: crDiscoveries.Namespace + "/" + crDiscoveries.Name,
 			},
 		},
 	}

--- a/pkg/manager/internal/controllers/customresourcediscoveryset_controller_test.go
+++ b/pkg/manager/internal/controllers/customresourcediscoveryset_controller_test.go
@@ -69,7 +69,7 @@ func TestCustomResourceDiscoverySetReconciler(t *testing.T) {
 			Name:      "couchdb.us-east-1",
 			Namespace: "hans",
 			Labels: map[string]string{
-				crDiscoveriesLabel: crDiscoveries.Namespace + "/" + crDiscoveries.Name,
+				crDiscoveriesLabel: crDiscoveries.Namespace + "." + crDiscoveries.Name,
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixed the customResourceDiscoverySet Bug. The bug is as follows:

* 2 provides use the same-named `CustomResourceDiscoverySet`
* The `	// Cleanup uncontrolled CRDiscoveries` which was intended to clean up CRDiscoveries for deleted service clusters assassinates other providers `CRDiscoveries`. Why? Because the lookup isn't namespace bound but crosses the namespace boundary. 

This PR fixes this in 2 ways, for extra safety:
* the lookup is now namespace bound
* the label value is now namespace aware

```release-note
NONE
```
