### PR TITLE
Add common labels to service selector, to avoid service endpoint overlap

### DIFF
--- a/pkg/internal/resources/apiserver/apiserver.go
+++ b/pkg/internal/resources/apiserver/apiserver.go
@@ -196,7 +196,7 @@ func Manifests(c Config) ([]unstructured.Unstructured, error) {
 		}
 		labels[constants.NameLabel] = "apiserver"
 		labels[constants.InstanceLabel] = c.Name
-		labels[constants.ManagedbyLabel] = constants.ManagedbyKubeCarrierOperator
+		labels[constants.ManagedByLabel] = constants.ManagedByKubeCarrierOperator
 		labels[constants.VersionLabel] = v.Version
 		obj.SetLabels(labels)
 	}

--- a/pkg/internal/resources/catapult/catapult.go
+++ b/pkg/internal/resources/catapult/catapult.go
@@ -72,7 +72,7 @@ func Manifests(c Config) ([]unstructured.Unstructured, error) {
 		CommonLabels: map[string]string{
 			constants.NameLabel:      "catapult",
 			constants.InstanceLabel:  c.Name,
-			constants.ManagedbyLabel: constants.ManagedbyKubeCarrierOperator,
+			constants.ManagedByLabel: constants.ManagedByKubeCarrierOperator,
 		},
 		Resources: []string{"../default"},
 		PatchesStrategicMerge: []types.PatchStrategicMerge{
@@ -302,7 +302,7 @@ func Manifests(c Config) ([]unstructured.Unstructured, error) {
 		labels[constants.VersionLabel] = v.Version
 		labels[constants.NameLabel] = "catapult"
 		labels[constants.InstanceLabel] = c.Name
-		labels[constants.ManagedbyLabel] = constants.ManagedbyKubeCarrierOperator
+		labels[constants.ManagedByLabel] = constants.ManagedByKubeCarrierOperator
 		obj.SetLabels(labels)
 	}
 	return objects, nil

--- a/pkg/internal/resources/catapult/catapult.go
+++ b/pkg/internal/resources/catapult/catapult.go
@@ -300,6 +300,9 @@ func Manifests(c Config) ([]unstructured.Unstructured, error) {
 			labels = map[string]string{}
 		}
 		labels[constants.VersionLabel] = v.Version
+		labels[constants.NameLabel] = "catapult"
+		labels[constants.InstanceLabel] = c.Name
+		labels[constants.ManagedbyLabel] = constants.ManagedbyKubeCarrierOperator
 		obj.SetLabels(labels)
 	}
 	return objects, nil

--- a/pkg/internal/resources/catapult/catapult.go
+++ b/pkg/internal/resources/catapult/catapult.go
@@ -69,6 +69,11 @@ func Manifests(c Config) ([]unstructured.Unstructured, error) {
 				NewTag: v.Version,
 			},
 		},
+		CommonLabels: map[string]string{
+			constants.NameLabel:      "catapult",
+			constants.InstanceLabel:  c.Name,
+			constants.ManagedbyLabel: constants.ManagedbyKubeCarrierOperator,
+		},
 		Resources: []string{"../default"},
 		PatchesStrategicMerge: []types.PatchStrategicMerge{
 			"manager_env_patch.yaml",
@@ -294,9 +299,6 @@ func Manifests(c Config) ([]unstructured.Unstructured, error) {
 		if labels == nil {
 			labels = map[string]string{}
 		}
-		labels[constants.NameLabel] = "catapult"
-		labels[constants.InstanceLabel] = c.Name
-		labels[constants.ManagedbyLabel] = constants.ManagedbyKubeCarrierOperator
 		labels[constants.VersionLabel] = v.Version
 		obj.SetLabels(labels)
 	}

--- a/pkg/internal/resources/catapult/catapult.golden.yaml
+++ b/pkg/internal/resources/catapult/catapult.golden.yaml
@@ -357,6 +357,9 @@
   metadata:
     creationTimestamp: null
     labels:
+      app.kubernetes.io/instance: db.eu-west-1
+      app.kubernetes.io/managed-by: kubecarrier-operator
+      app.kubernetes.io/name: catapult
       app.kubernetes.io/version: was not build properly
       kubecarrier.io/manager: "true"
     name: couchdbinternals.eu-west-1.provider-view-only

--- a/pkg/internal/resources/catapult/catapult.golden.yaml
+++ b/pkg/internal/resources/catapult/catapult.golden.yaml
@@ -178,11 +178,17 @@
     replicas: 1
     selector:
       matchLabels:
+        app.kubernetes.io/instance: db.eu-west-1
+        app.kubernetes.io/managed-by: kubecarrier-operator
+        app.kubernetes.io/name: catapult
         control-plane: manager
         kubecarrier.io/role: catapult
     template:
       metadata:
         labels:
+          app.kubernetes.io/instance: db.eu-west-1
+          app.kubernetes.io/managed-by: kubecarrier-operator
+          app.kubernetes.io/name: catapult
           control-plane: manager
           kubecarrier.io/role: catapult
       spec:
@@ -309,6 +315,9 @@
     - port: 443
       targetPort: 9443
     selector:
+      app.kubernetes.io/instance: db.eu-west-1
+      app.kubernetes.io/managed-by: kubecarrier-operator
+      app.kubernetes.io/name: catapult
       control-plane: manager
       kubecarrier.io/role: catapult
 - apiVersion: cert-manager.io/v1alpha2
@@ -348,9 +357,6 @@
   metadata:
     creationTimestamp: null
     labels:
-      app.kubernetes.io/instance: db.eu-west-1
-      app.kubernetes.io/managed-by: kubecarrier-operator
-      app.kubernetes.io/name: catapult
       app.kubernetes.io/version: was not build properly
       kubecarrier.io/manager: "true"
     name: couchdbinternals.eu-west-1.provider-view-only

--- a/pkg/internal/resources/constants/labels.go
+++ b/pkg/internal/resources/constants/labels.go
@@ -21,7 +21,7 @@ const (
 	NameLabel      = "app.kubernetes.io/name"
 	InstanceLabel  = "app.kubernetes.io/instance"
 	VersionLabel   = "app.kubernetes.io/version"
-	ManagedbyLabel = "app.kubernetes.io/managed-by"
+	ManagedByLabel = "app.kubernetes.io/managed-by"
 
-	ManagedbyKubeCarrierOperator = "kubecarrier-operator"
+	ManagedByKubeCarrierOperator = "kubecarrier-operator"
 )

--- a/pkg/internal/resources/elevator/elevator.go
+++ b/pkg/internal/resources/elevator/elevator.go
@@ -65,6 +65,11 @@ func Manifests(c Config) ([]unstructured.Unstructured, error) {
 				NewTag: v.Version,
 			},
 		},
+		CommonLabels: map[string]string{
+			constants.NameLabel:      "elevator",
+			constants.InstanceLabel:  c.Name,
+			constants.ManagedbyLabel: constants.ManagedbyKubeCarrierOperator,
+		},
 		Resources: []string{
 			"../default",
 		},
@@ -303,9 +308,6 @@ func Manifests(c Config) ([]unstructured.Unstructured, error) {
 		if labels == nil {
 			labels = map[string]string{}
 		}
-		labels[constants.NameLabel] = "elevator"
-		labels[constants.InstanceLabel] = c.Name
-		labels[constants.ManagedbyLabel] = constants.ManagedbyKubeCarrierOperator
 		labels[constants.VersionLabel] = v.Version
 		obj.SetLabels(labels)
 	}

--- a/pkg/internal/resources/elevator/elevator.go
+++ b/pkg/internal/resources/elevator/elevator.go
@@ -68,7 +68,7 @@ func Manifests(c Config) ([]unstructured.Unstructured, error) {
 		CommonLabels: map[string]string{
 			constants.NameLabel:      "elevator",
 			constants.InstanceLabel:  c.Name,
-			constants.ManagedbyLabel: constants.ManagedbyKubeCarrierOperator,
+			constants.ManagedByLabel: constants.ManagedByKubeCarrierOperator,
 		},
 		Resources: []string{
 			"../default",
@@ -311,7 +311,7 @@ func Manifests(c Config) ([]unstructured.Unstructured, error) {
 		labels[constants.VersionLabel] = v.Version
 		labels[constants.NameLabel] = "elevator"
 		labels[constants.InstanceLabel] = c.Name
-		labels[constants.ManagedbyLabel] = constants.ManagedbyKubeCarrierOperator
+		labels[constants.ManagedByLabel] = constants.ManagedByKubeCarrierOperator
 		obj.SetLabels(labels)
 	}
 	return objects, nil

--- a/pkg/internal/resources/elevator/elevator.go
+++ b/pkg/internal/resources/elevator/elevator.go
@@ -309,6 +309,9 @@ func Manifests(c Config) ([]unstructured.Unstructured, error) {
 			labels = map[string]string{}
 		}
 		labels[constants.VersionLabel] = v.Version
+		labels[constants.NameLabel] = "elevator"
+		labels[constants.InstanceLabel] = c.Name
+		labels[constants.ManagedbyLabel] = constants.ManagedbyKubeCarrierOperator
 		obj.SetLabels(labels)
 	}
 	return objects, nil

--- a/pkg/internal/resources/elevator/elevator.golden.yaml
+++ b/pkg/internal/resources/elevator/elevator.golden.yaml
@@ -198,11 +198,17 @@
     replicas: 1
     selector:
       matchLabels:
+        app.kubernetes.io/instance: db.eu-west-1
+        app.kubernetes.io/managed-by: kubecarrier-operator
+        app.kubernetes.io/name: elevator
         control-plane: manager
         kubecarrier.io/role: elevator
     template:
       metadata:
         labels:
+          app.kubernetes.io/instance: db.eu-west-1
+          app.kubernetes.io/managed-by: kubecarrier-operator
+          app.kubernetes.io/name: elevator
           control-plane: manager
           kubecarrier.io/role: elevator
       spec:
@@ -318,6 +324,9 @@
     - port: 443
       targetPort: 9443
     selector:
+      app.kubernetes.io/instance: db.eu-west-1
+      app.kubernetes.io/managed-by: kubecarrier-operator
+      app.kubernetes.io/name: elevator
       control-plane: manager
       kubecarrier.io/role: elevator
 - apiVersion: cert-manager.io/v1alpha2
@@ -357,9 +366,6 @@
   metadata:
     creationTimestamp: null
     labels:
-      app.kubernetes.io/instance: db.eu-west-1
-      app.kubernetes.io/managed-by: kubecarrier-operator
-      app.kubernetes.io/name: elevator
       app.kubernetes.io/version: was not build properly
       kubecarrier.io/manager: "true"
     name: couchdbs.eu-west-1.provider-view-only
@@ -377,9 +383,6 @@
   metadata:
     creationTimestamp: null
     labels:
-      app.kubernetes.io/instance: db.eu-west-1
-      app.kubernetes.io/managed-by: kubecarrier-operator
-      app.kubernetes.io/name: elevator
       app.kubernetes.io/version: was not build properly
       kubecarrier.io/apiserver: "true"
     name: couchdbs.eu-west-1.provider

--- a/pkg/internal/resources/elevator/elevator.golden.yaml
+++ b/pkg/internal/resources/elevator/elevator.golden.yaml
@@ -366,6 +366,9 @@
   metadata:
     creationTimestamp: null
     labels:
+      app.kubernetes.io/instance: db.eu-west-1
+      app.kubernetes.io/managed-by: kubecarrier-operator
+      app.kubernetes.io/name: elevator
       app.kubernetes.io/version: was not build properly
       kubecarrier.io/manager: "true"
     name: couchdbs.eu-west-1.provider-view-only
@@ -383,6 +386,9 @@
   metadata:
     creationTimestamp: null
     labels:
+      app.kubernetes.io/instance: db.eu-west-1
+      app.kubernetes.io/managed-by: kubecarrier-operator
+      app.kubernetes.io/name: elevator
       app.kubernetes.io/version: was not build properly
       kubecarrier.io/apiserver: "true"
     name: couchdbs.eu-west-1.provider

--- a/pkg/internal/resources/ferry/ferry.go
+++ b/pkg/internal/resources/ferry/ferry.go
@@ -137,7 +137,7 @@ func Manifests(c Config) ([]unstructured.Unstructured, error) {
 		}
 		labels[constants.NameLabel] = "ferry"
 		labels[constants.InstanceLabel] = c.Name
-		labels[constants.ManagedbyLabel] = constants.ManagedbyKubeCarrierOperator
+		labels[constants.ManagedByLabel] = constants.ManagedByKubeCarrierOperator
 		labels[constants.VersionLabel] = v.Version
 		obj.SetLabels(labels)
 	}

--- a/pkg/internal/resources/manager/manager.go
+++ b/pkg/internal/resources/manager/manager.go
@@ -104,7 +104,7 @@ func Manifests(c Config) ([]unstructured.Unstructured, error) {
 		}
 		labels[constants.NameLabel] = "kubecarrier-controller-manager"
 		labels[constants.InstanceLabel] = c.Name
-		labels[constants.ManagedbyLabel] = constants.ManagedbyKubeCarrierOperator
+		labels[constants.ManagedByLabel] = constants.ManagedByKubeCarrierOperator
 		labels[constants.VersionLabel] = v.Version
 		obj.SetLabels(labels)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
When registering multiple CRDs in the same namespace the webhook selector will mach all elevator/catapult instances, do round robin load balancing and lead to this error:

```
Error from server (InternalError): error when creating "./master_cluster/kubecarrier/services/cert-svc1-tenant1.yaml": Internal error occurred: failed calling webhook "mcertificate.kubecarrier.io": Post https://certificates-svc-1-catapult-webhook-service.provider-1.svc:443/mutate-svc-1-provider-1-v1alpha2-certificate?timeout=30s: x509: certificate is valid for certificates-svc-2-catapult-webhook-service.provider-1.svc, certificates-svc-2-catapult-webhook-service.provider-1.svc.cluster.local, not certificates-svc-1-catapult-webhook-service.provider-1.svc
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
