### PR TITLE
Add generator for example objects from a JSON Schema

### DIFF
--- a/pkg/manager/internal/controllers/util.go
+++ b/pkg/manager/internal/controllers/util.go
@@ -17,9 +17,14 @@ limitations under the License.
 package controllers
 
 import (
+	"encoding/json"
+	"strings"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const (
@@ -40,4 +45,62 @@ func getStorageVersion(crd *apiextensionsv1.CustomResourceDefinition) string {
 type object interface {
 	runtime.Object
 	metav1.Object
+}
+
+func exampleObjectFromJSONSchema(
+	gvk schema.GroupVersionKind,
+	jsonSchema apiextensionsv1.JSONSchemaProps) (*unstructured.Unstructured, error) {
+
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{},
+	}
+	walkExampleObject(jsonSchema, true, obj.Object)
+	obj.SetGroupVersionKind(gvk)
+	obj.SetName(strings.ToLower(gvk.Kind))
+
+	return obj, nil
+}
+
+// walkExampleObject builds an example object from a JSONSchema.
+func walkExampleObject(in apiextensionsv1.JSONSchemaProps, firstLevel bool, obj map[string]interface{}) {
+
+	for field, props := range in.Properties {
+		if firstLevel {
+			// skip common fields added by SetGroupVersionKind
+			switch field {
+			case "apiVersion", "metadata", "kind", "status":
+				continue
+			}
+		}
+		if props.Default != nil {
+			var defaultValue interface{}
+			_ = json.Unmarshal(props.Default.Raw, &defaultValue)
+			obj[field] = defaultValue
+			continue
+		}
+
+		switch props.Type {
+		case "string":
+			obj[field] = ""
+		case "boolean":
+			obj[field] = false
+		case "integer", "number":
+			obj[field] = 1
+		case "array":
+			obj[field] = []interface{}{}
+
+			// array sub object
+			if props.Items.Schema != nil && props.Items.Schema.Properties != nil {
+				item := map[string]interface{}{}
+				walkExampleObject(*props.Items.Schema, false, item)
+				obj[field] = []interface{}{item}
+			}
+
+		case "object":
+			obj[field] = map[string]interface{}{}
+			walkExampleObject(props, false, obj[field].(map[string]interface{}))
+		default:
+			obj[field] = nil
+		}
+	}
 }

--- a/pkg/manager/internal/controllers/util_test.go
+++ b/pkg/manager/internal/controllers/util_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2019 The KubeCarrier Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/yaml"
+)
+
+const exampleObjectSchema string = `
+type: object
+properties:
+  apiVersion:
+    type: string
+  kind:
+    type: string
+  spec:
+    type: object
+    properties:
+      prop1:
+        type: string
+      prop2:
+        type: string
+        default: test123
+      stringArray:
+        type: array
+        items:
+          type: string
+      roles:
+        type: array
+        items:
+          properties:
+            name:
+              type: string
+  status:
+    type: object
+    properties:
+      phase:
+        type: string
+      conditions:
+        type: array
+        items:
+          properties:
+            message:
+              type: string
+            reason:
+              type: string
+`
+
+func TestExampleObject(t *testing.T) {
+	jsonSchema := apiextensionsv1.JSONSchemaProps{}
+	require.NoError(t, yaml.Unmarshal([]byte(exampleObjectSchema), &jsonSchema), "unmarshal schema yaml")
+
+	gvk := schema.GroupVersionKind{
+		Group:   "test.kubecarrier.io",
+		Version: "v1alpha1",
+		Kind:    "Test",
+	}
+
+	obj, err := exampleObjectFromJSONSchema(gvk, jsonSchema)
+	require.NoError(t, err)
+
+	// Resulting Example Object
+	// apiVersion: test.kubecarrier.io/v1alpha1
+	// kind: Test
+	// metadata:
+	//   name: test
+	// spec:
+	//   prop1: ""
+	//   prop2: test123
+	//   roles:
+	//   - name: ""
+	//   stringArray: []
+	assert.Equal(t, map[string]interface{}{
+		"apiVersion": "test.kubecarrier.io/v1alpha1",
+		"kind":       "Test",
+		"metadata": map[string]interface{}{
+			"name": "test",
+		},
+		"spec": map[string]interface{}{
+			"prop1": "",
+			"prop2": "test123", // from field defaults
+			"roles": []interface{}{
+				map[string]interface{}{
+					"name": "",
+				},
+			},
+			"stringArray": []interface{}{},
+		},
+	}, obj.Object)
+
+	j, _ := yaml.Marshal(obj)
+	fmt.Println(string(j))
+	t.Fail()
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds code that generates examples of CRDs registered in KubeCarrier.

e.g.

This Schema:
```yaml
type: object
properties:
  apiVersion:
    type: string
  kind:
    type: string
  spec:
    type: object
    properties:
      prop1:
        type: string
      prop2:
        type: string
        default: test123
      stringArray:
        type: array
        items:
          type: string
      roles:
        type: array
        items:
          properties:
            name:
              type: string
```

Will result in this example object (when also adding GVK):

```yaml
apiVersion: test.kubecarrier.io/v1alpha1
kind: Test
metadata:
  name: test
spec:
  prop1: ""
  prop2: test123
  roles:
  - name: ""
  stringArray: []
```

This generated example object provides a quick overview of the API (at least easier and quicker than going through the json schema by hand) and can be used to prefill the create dialog in the KubeCarrier UI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This function could be implemented in 3 different places:
- Within the `DerivedCustomResource` controller (adding to status) and copy the information to `Offering` objects in the `Catalog` controller
- In the API Server (don't really like this/needs recalculation every request)
- Not in KubeCarrier -> Clients need to do this

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
```
