### PR TITLE
Enable make docs in make generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ endif
 .PHONY: generate-config
 
 # Runs all code generators
-generate: generate-grpc generate-config
+generate: generate-grpc generate-config docs
 .PHONY: generate
 
 # Create API Reference docs

--- a/docs/api_reference/_index.md
+++ b/docs/api_reference/_index.md
@@ -844,6 +844,7 @@ CRDVersion holds CRD version specific details.
 | ----- | ----------- | ------ | -------- |
 | name | Name of this version, for example: v1, v1alpha1, v1beta1 | string | true |
 | schema | Schema of this CRD version. | *apiextensionsv1.CustomResourceValidation | false |
+| storage | Storage indicates this version should be used when persisting custom resources to storage. There must be exactly one version with storage=true. | bool | false |
 
 [Back to Group](#catalog)
 
@@ -1121,6 +1122,9 @@ The `operator.kubecarrier.io` API group contains objects to interact with the Ku
 * [APIServerOIDCConfig.operator.kubecarrier.io/v1alpha1](#apiserveroidcconfigoperatorkubecarrieriov1alpha1)
 * [APIServerSpec.operator.kubecarrier.io/v1alpha1](#apiserverspecoperatorkubecarrieriov1alpha1)
 * [APIServerStatus.operator.kubecarrier.io/v1alpha1](#apiserverstatusoperatorkubecarrieriov1alpha1)
+* [Anonymous.operator.kubecarrier.io/v1alpha1](#anonymousoperatorkubecarrieriov1alpha1)
+* [AuthenticationConfig.operator.kubecarrier.io/v1alpha1](#authenticationconfigoperatorkubecarrieriov1alpha1)
+* [ServiceAccount.operator.kubecarrier.io/v1alpha1](#serviceaccountoperatorkubecarrieriov1alpha1)
 * [StaticUsers.operator.kubecarrier.io/v1alpha1](#staticusersoperatorkubecarrieriov1alpha1)
 * [Catapult.operator.kubecarrier.io/v1alpha1](#catapultoperatorkubecarrieriov1alpha1)
 * [CatapultCondition.operator.kubecarrier.io/v1alpha1](#catapultconditionoperatorkubecarrieriov1alpha1)
@@ -1190,7 +1194,6 @@ APIServerList contains a list of APIServer
 | ----- | ----------- | ------ | -------- |
 | issuerURL | IssuerURL is the URL the provider signs ID Tokens as. This will be the \"iss\" field of all tokens produced by the provider and is used for configuration discovery.\n\nThe URL is usually the provider's URL without a path, for example \"https://accounts.google.com\" or \"https://login.salesforce.com\".\n\nThe provider must implement configuration discovery. See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig | string | true |
 | clientID | ClientID the JWT must be issued for, the \"sub\" field. This plugin only trusts a single client to ensure the plugin can be used with public providers.\n\nThe plugin supports the \"authorized party\" OpenID Connect claim, which allows specialized providers to issue tokens to a client for a different client. See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken | string | true |
-| apiAudiences | APIAudiences are the audiences that the API server identitifes as. The (API audiences unioned with the ClientIDs) should have a non-empty intersection with the request's target audience. This preserves the behavior of the OIDC authenticator pre-introduction of API audiences. | authenticator.Audiences | false |
 | certificateAuthority | CertificateAuthority references the secret containing issuer's CA in a PEM encoded root certificate of the provider. | [ObjectReference.operator.kubecarrier.io/v1alpha1](#objectreferenceoperatorkubecarrieriov1alpha1) | true |
 | usernameClaim | UsernameClaim is the JWT field to use as the user's username. | string | true |
 | usernamePrefix | UsernamePrefix, if specified, causes claims mapping to username to be prefix with the provided value. A value \"oidc:\" would result in usernames like \"oidc:john\". | string | false |
@@ -1208,8 +1211,8 @@ APIServerSpec defines the desired state of APIServer
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | tlsSecretRef | TLSSecretRef references the TLS certificate and private key for serving the KubeCarrier API. | *[ObjectReference.operator.kubecarrier.io/v1alpha1](#objectreferenceoperatorkubecarrieriov1alpha1) | false |
-| oidc | OIDC specifies OpenID Connect configuration for API Server authentication | *[APIServerOIDCConfig.operator.kubecarrier.io/v1alpha1](#apiserveroidcconfigoperatorkubecarrieriov1alpha1) | false |
-| staticUsers | StaticUsers specifies static users configuration for API Server authentication | *[StaticUsers.operator.kubecarrier.io/v1alpha1](#staticusersoperatorkubecarrieriov1alpha1) | false |
+| authentication | Authentication configuration | Authentication.operator.kubecarrier.io/v1alpha1 | false |
+| logLevel | LogLevel | *int.operator.kubecarrier.io/v1alpha1 | false |
 
 [Back to Group](#operator)
 
@@ -1222,6 +1225,37 @@ APIServerStatus defines the observed state of APIServer
 | observedGeneration | ObservedGeneration is the most recent generation observed for this APIServer by the controller. | int64 | false |
 | conditions | Conditions represents the latest available observations of a APIServer's current state. | [][APIServerCondition.operator.kubecarrier.io/v1alpha1](#apiserverconditionoperatorkubecarrieriov1alpha1) | false |
 | phase | DEPRECATED. Phase represents the current lifecycle state of this object. Consider this field DEPRECATED, it will be removed as soon as there is a mechanism to map conditions to strings when printing the property. This is only for display purpose, for everything else use conditions. | APIServerPhaseType.operator.kubecarrier.io/v1alpha1 | false |
+
+[Back to Group](#operator)
+
+### Anonymous.operator.kubecarrier.io/v1alpha1
+
+
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+
+[Back to Group](#operator)
+
+### AuthenticationConfig.operator.kubecarrier.io/v1alpha1
+
+
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| oidc | OIDC specifies OpenID Connect configuration for API Server authentication | *[APIServerOIDCConfig.operator.kubecarrier.io/v1alpha1](#apiserveroidcconfigoperatorkubecarrieriov1alpha1) | false |
+| staticUsers | StaticUsers specifies static users configuration for API Server authentication | *[StaticUsers.operator.kubecarrier.io/v1alpha1](#staticusersoperatorkubecarrieriov1alpha1) | false |
+| serviceAccount | ServiceAccount specifies whether service account auth provider enabled | *[ServiceAccount.operator.kubecarrier.io/v1alpha1](#serviceaccountoperatorkubecarrieriov1alpha1) | false |
+| anonymous | Anonymous specifies whether anonymous auth provider enabled | *[Anonymous.operator.kubecarrier.io/v1alpha1](#anonymousoperatorkubecarrieriov1alpha1) | false |
+
+[Back to Group](#operator)
+
+### ServiceAccount.operator.kubecarrier.io/v1alpha1
+
+
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
 
 [Back to Group](#operator)
 
@@ -1284,6 +1318,8 @@ CatapultSpec defines the desired state of Catapult.
 | serviceClusterCRD | References the CRD in the ServiceCluster. | [CRDReference.operator.kubecarrier.io/v1alpha1](#crdreferenceoperatorkubecarrieriov1alpha1) | true |
 | serviceCluster | References the ServiceCluster object that this object belongs to. | [ObjectReference.operator.kubecarrier.io/v1alpha1](#objectreferenceoperatorkubecarrieriov1alpha1) | true |
 | webhookStrategy | WebhookStrategy configs the webhook of the CRD which is registered in the management cluster by this Catapult. There are two possible values for this configuration {None (by default), ServiceCluster} None (by default): Webhook will only check if there is an available ServiceClusterAssignment in the current Namespace. ServiceCluster: Webhook will call webhooks of the CRD in the ServiceCluster with dry-run flag. | corev1alpha1.WebhookStrategyType | false |
+| paused | Paused tell controller to pause reconciliation process and assume that Catapult is ready | PausedFlagType.operator.kubecarrier.io/v1alpha1 | false |
+| logLevel | LogLevel | *int.operator.kubecarrier.io/v1alpha1 | false |
 
 [Back to Group](#operator)
 
@@ -1347,6 +1383,8 @@ ElevatorSpec defines the desired state of Elevator.
 | providerCRD | References the provider or internal CRD, that should be created in the provider namespace. | [CRDReference.operator.kubecarrier.io/v1alpha1](#crdreferenceoperatorkubecarrieriov1alpha1) | true |
 | tenantCRD | References the public CRD that will be synced into the provider namespace. | [CRDReference.operator.kubecarrier.io/v1alpha1](#crdreferenceoperatorkubecarrieriov1alpha1) | true |
 | derivedCR | References the DerivedCustomResource controlling the Tenant-side CRD. | [ObjectReference.operator.kubecarrier.io/v1alpha1](#objectreferenceoperatorkubecarrieriov1alpha1) | true |
+| paused | Paused tell controller to pause reconciliation process and assume that Catapult is ready | PausedFlagType.operator.kubecarrier.io/v1alpha1 | false |
+| logLevel | LogLevel | *int.operator.kubecarrier.io/v1alpha1 | false |
 
 [Back to Group](#operator)
 
@@ -1417,6 +1455,8 @@ FerrySpec defines the desired state of Ferry.
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | kubeconfigSecret | KubeconfigSecret specifies the Kubeconfig to use when connecting to the ServiceCluster. | [ObjectReference.operator.kubecarrier.io/v1alpha1](#objectreferenceoperatorkubecarrieriov1alpha1) | true |
+| paused | Paused tell controller to pause reconciliation process and assume that Ferry is ready | PausedFlagType.operator.kubecarrier.io/v1alpha1 | false |
+| logLevel | LogLevel | *int.operator.kubecarrier.io/v1alpha1 | false |
 
 [Back to Group](#operator)
 
@@ -1476,6 +1516,8 @@ KubeCarrierSpec defines the desired state of KubeCarrier
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | api |  | [APIServerSpec.operator.kubecarrier.io/v1alpha1](#apiserverspecoperatorkubecarrieriov1alpha1) | false |
+| paused | Paused tell controller to pause reconciliation process and assume that KubaCarrier is ready | PausedFlagType.operator.kubecarrier.io/v1alpha1 | false |
+| logLevel | LogLevel | int.operator.kubecarrier.io/v1alpha1 | false |
 
 [Back to Group](#operator)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes our api-reference is outdated, this PR adds `make docs` in `make generate` so our lint can against that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
