### PR TITLE
check if status exists in management cluster object

### DIFF
--- a/pkg/catapult/internal/controllers/managementclusterobj_controller.go
+++ b/pkg/catapult/internal/controllers/managementclusterobj_controller.go
@@ -161,11 +161,13 @@ func (r *ManagementClusterObjReconciler) Reconcile(req ctrl.Request) (ctrl.Resul
 	}
 
 	// Sync Status from service cluster to management cluster
-	if err := unstructured.SetNestedField(
-		managementClusterObj.Object,
-		currentServiceClusterObj.Object["status"], "status"); err != nil {
-		return result, fmt.Errorf(
-			"updating %s .status: %w", r.ManagementClusterGVK.Kind, err)
+	if status, ok := currentServiceClusterObj.Object["status"]; ok {
+		if err := unstructured.SetNestedField(
+			managementClusterObj.Object,
+			status, "status"); err != nil {
+			return result, fmt.Errorf(
+				"updating %s .status: %w", r.ManagementClusterGVK.Kind, err)
+		}
 	}
 	if err = util.UpdateObservedGeneration(
 		currentServiceClusterObj, managementClusterObj); err != nil {


### PR DESCRIPTION
don't try to update management cluster object status if it does not exist in the service cluster object

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #549 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
