### PR TITLE
Create get-kubeconfig.sh

### DIFF
--- a/hack/get-kubeconfig.sh
+++ b/hack/get-kubeconfig.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# Copyright 2020 The KubeCarrier Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu -o pipefail
+
+# Set OS specific values.
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    BASE64_DECODE_FLAG="-d"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    BASE64_DECODE_FLAG="-D"
+elif [[ "$OSTYPE" == "linux-musl" ]]; then
+    BASE64_DECODE_FLAG="-d"
+else
+    echo "Unknown OS ${OSTYPE}"
+    exit 1
+fi
+
+kubectl apply -f - <<EOF >> /dev/null
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubecarrier-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubecarrier-sa
+  namespace: kubecarrier-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubecarrier-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubecarrier-crb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubecarrier-role
+subjects:
+- kind: ServiceAccount
+  name: kubecarrier-sa
+  namespace: kubecarrier-system
+EOF
+# Get the service account token and CA cert.
+SA_SECRET_NAME=$(kubectl get -n kubecarrier-system sa/kubecarrier-sa -o "jsonpath={.secrets[0]..name}")
+# Note: service account token is stored base64-encoded in the secret but must
+# be plaintext in kubeconfig.
+SA_TOKEN=$(kubectl get -n kubecarrier-system secrets/${SA_SECRET_NAME} -o "jsonpath={.data['token']}" | base64 ${BASE64_DECODE_FLAG})
+CA_CERT=$(kubectl get -n kubecarrier-system secrets/${SA_SECRET_NAME} -o "jsonpath={.data['ca\.crt']}")
+
+# Extract cluster IP from the current context
+CURRENT_CONTEXT=$(kubectl config current-context)
+CURRENT_CLUSTER=$(kubectl config view -o jsonpath="{.contexts[?(@.name == \"${CURRENT_CONTEXT}\"})].context.cluster}")
+CURRENT_CLUSTER_ADDR=$(kubectl config view -o jsonpath="{.clusters[?(@.name == \"${CURRENT_CLUSTER}\"})].cluster.server}")
+
+echo "apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: ${CA_CERT}
+    server: ${CURRENT_CLUSTER_ADDR}
+  name: ${CURRENT_CLUSTER}
+contexts:
+- context:
+    cluster: ${CURRENT_CLUSTER}
+    user: kubecarrier-sa
+  name: ${CURRENT_CONTEXT}
+current-context: ${CURRENT_CONTEXT}
+kind: Config
+preferences: {}
+users:
+- name: kubecarrier-sa
+  user:
+    token: ${SA_TOKEN}
+"

--- a/hack/get-servicecluster-kubeconfig.sh
+++ b/hack/get-servicecluster-kubeconfig.sh
@@ -39,34 +39,11 @@ kind: ServiceAccount
 metadata:
   name: kubecarrier-sa
   namespace: kubecarrier-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: kubecarrier-role
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
-  - list
-  - update
-  - watch
----
+EOF
+
+kubectl apply -f config/serviceCluster/role.yaml  >> /dev/null
+
+kubectl apply -f - <<EOF >> /dev/null
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -74,12 +51,13 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kubecarrier-role
+  name: kubecarrier:service-cluster-admin
 subjects:
 - kind: ServiceAccount
   name: kubecarrier-sa
   namespace: kubecarrier-system
 EOF
+
 # Get the service account token and CA cert.
 SA_SECRET_NAME=$(kubectl get -n kubecarrier-system sa/kubecarrier-sa -o "jsonpath={.secrets[0]..name}")
 # Note: service account token is stored base64-encoded in the secret but must


### PR DESCRIPTION
this script helps to create ServiceAccount in the Service cluster we all needed permissions for KubeCarrier to work and generate kubeconfig using this ServiceAccount. A user only needs to add permissions needed for their operator to work

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #552 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
